### PR TITLE
docs: Add  ADRs (Architecture Decision Records)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,9 @@ docs/database/merise/learn-dev_mld_geo.json
 ### Python Virtual Environment
 ### ~~~~~~~~~~~~~~~~~~~~~~~~~~
 venv/
+
+### ~~~~~~~~~~~~~~~~~~~~~~~~~~
+### Claude
+### ~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Do not impose my own Claude tooling configuration to the team
+.mcp.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,8 +3,7 @@
 
 ## Welcome
 
-Thank you for your interest in contributing to **learn-dev**, a learning platform
-that uses hands-on practice, automated assessment and real-time feedback to teach programming.
+Thank you for your interest in contributing to **learn-dev**, a learning platform to teach programming.
 
 Whether you're fixing a bug, proposing a new feature, improving documentation,
 or writing tests, every contribution helps make this project better.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,15 @@ Read the [Prerequisites section of the README](README.md#prerequisites).
 
 The code reference documentation is not yet available and will be added to this repository in a future update.
 
+#### Architecture Decision Records (ADR)
+
+Significant architectural and design decisions are recorded as **ADRs** under
+[`docs/adr/`](docs/adr/), using the **MADR** short form. ADRs are an
+append-only, numbered log: a decision is never rewritten; a new ADR supersedes
+an old one. Files are named `NNNN-short-title-in-kebab-case.md` (4-digit
+zero-padded sequence). To add one, copy [`docs/adr/template.md`](docs/adr/template.md)
+and add it to the index in [`docs/adr/README.md`](docs/adr/README.md).
+
 #### Architecture Overview
 
 _learn-dev_ is a Web-based client-server application

--- a/README.md
+++ b/README.md
@@ -2,10 +2,9 @@
 
 ## Presentation
 
-> An interactive programming learning platform with automated assessment and hands-on practice.  
+> An interactive programming learning platform.  
 
-This project aims to enable students to learn programming through hands-on practice
-with automated assessment and real-time feedback.
+This project aims to enable students to learn programming.
 
 It is also my capstone project for the [Web and Web Mobile Developer REAC certification](https://www.francecompetences.fr/recherche/rncp/37674/), which I am currently undergoing at [La Plateforme_](https://laplateforme.io).
 
@@ -15,7 +14,6 @@ It is also my capstone project for the [Web and Web Mobile Developer REAC certif
 ## Goals
 
 - Provide an interactive environment for learning programming concepts
-- Implement automated code assessment and feedback
 - Support multiple user roles (such as Student, Instructor, Admin)
 - Demonstrate full-stack development skills using industry standards
 

--- a/docs/adr/0001-use-server-side-sessions-over-jwt.md
+++ b/docs/adr/0001-use-server-side-sessions-over-jwt.md
@@ -1,0 +1,57 @@
+# Use server-side sessions instead of JWT for user authentication
+
+- Status: accepted
+- Date: 2026-06-06
+- Deciders: Eric Bouchut
+
+## Context and Problem Statement
+
+The platform was initially designed with a React single-page application (SPA)
+talking to a REST API on a separate origin — a setup that naturally suggests
+stateless JWT authentication. The frontend has since changed to Thymeleaf,
+which renders HTML server-side and is served from the same origin as the
+backend. How should browser users be authenticated under this new architecture?
+
+## Decision Drivers
+
+- Fit with a same-origin, server-rendered architecture
+- Security: token theft (XSS), revocation, CSRF protection
+- Implementation simplicity and framework support
+- Avoiding unnecessary moving parts
+
+## Considered Options
+
+- Server-side sessions (Spring Security `formLogin` + `HttpSession`)
+- JWT stored in the browser (cookie or `localStorage`)
+
+## Decision Outcome
+
+Chosen: **server-side sessions**, because Thymeleaf is same-origin and
+server-rendered, so the browser only needs a session cookie — natively
+supported by Spring Security. Storing a JWT in a cookie would effectively
+re-implement a session, but with weaker security and more code.
+
+### Consequences
+
+- Good: native Spring Security support (`formLogin` + `HttpSession`); easy
+  server-side revocation (invalidate the session); built-in CSRF token
+  integrated with Thymeleaf forms; `HttpOnly` cookie not readable by JS.
+- Good: removed the `refresh_tokens` table, a JWT-only concern.
+- Trade-off: sessions are stateful; horizontal scaling across instances would
+  need a shared session store (e.g. Spring Session + Redis). Acceptable for a
+  single-instance application.
+- Note: JWT/OAuth2 may be reintroduced later for a *different* boundary — a
+  future mobile app or public API — without changing this decision for the web UI.
+
+## Pros and Cons of the Options
+
+### Server-side sessions
+
+- 👍 Simple; revocable; CSRF built-in; `HttpOnly; Secure; SameSite` cookie
+- 👎 Stateful; needs a shared store to scale horizontally
+
+### JWT in the browser
+
+- 👍 Stateless; fits a separate-origin SPA or mobile client
+- 👎 XSS theft risk (`localStorage`); hard to revoke; manual expiry/refresh;
+  reinvents a session if placed in a cookie

--- a/docs/adr/0002-service-to-service-auth-via-service-token.md
+++ b/docs/adr/0002-service-to-service-auth-via-service-token.md
@@ -1,0 +1,77 @@
+# Authenticate service-to-service calls with a service token
+
+- Status: proposed
+- Date: 2026-06-06
+- Deciders: Eric Bouchut
+
+## Context and Problem Statement
+
+Introducing microservices (for example a notification/email service) creates a
+new security boundary: the web application authenticating itself when it calls
+an internal service. This is distinct from browser-to-application
+authentication, which is handled by server-side sessions (see ADR-0001). The
+browser never calls internal services directly, so the user's login is not
+involved here. How should the web application authenticate to an internal
+service?
+
+## Decision Drivers
+
+- Small, fixed set of internal services on a trusted Docker network
+- Setup and operational cost (extra infrastructure to run and maintain)
+- Security of the credential in transit and at rest
+- Keeping the architecture proportionate to a capstone project
+
+## Considered Options
+
+- Service token — shared secret (Tier 1)
+- Service token — self-issued service JWT, signed by the caller (Tier 2)
+- OAuth2 client-credentials grant (requires an Authorization Server)
+- Mutual TLS (mTLS)
+
+## Decision Outcome
+
+Chosen: **a service token** that authenticates the calling *service* (not a
+user). mTLS was rejected for now because it requires managing a certificate
+authority and per-service certificate lifecycle — disproportionate for a few
+services. The full OAuth2 client-credentials grant was rejected for now because
+it requires standing up and operating an Authorization Server. The remaining
+choice between Tier 1 (shared secret) and Tier 2 (self-issued JWT) is still
+open; this ADR will be updated to `accepted` once that selection is made.
+
+### Consequences
+
+- Good: no additional infrastructure or container required; minimal setup.
+- Good: the credential authenticates the service, so no user JWT is needed for
+  internal calls; `refresh_tokens` remains unnecessary.
+- Trade-off (Tier 1): a static shared secret must be stored securely
+  (1Password/env), transmitted over TLS, and rotated; either side leaking it
+  compromises the pair.
+- Trade-off (Tier 2): introduces RSA key management (private key on the caller,
+  public key on the callee) in exchange for token expiry and claims.
+- Open: Tier 1 vs Tier 2 not yet decided; OAuth2 client-credentials remains a
+  future option if a dedicated Authorization Server is introduced.
+
+## Pros and Cons of the Options
+
+### Service token — shared secret (Tier 1)
+
+- 👍 Lowest cost; no new infrastructure; ~15 lines to implement
+- 👎 Symmetric secret; both sides can forge; no built-in expiry
+
+### Service token — self-issued JWT (Tier 2)
+
+- 👍 Asymmetric (callee holds only the public key, cannot forge); token expiry
+  and claims; validated by Spring as an OAuth2 Resource Server
+- 👎 RSA key management; more moving parts than a shared secret
+
+### OAuth2 client-credentials grant
+
+- 👍 Standards-based; short-lived tokens; centralized client management
+- 👎 Requires an Authorization Server to run and maintain (Spring Authorization
+  Server or Keycloak)
+
+### Mutual TLS (mTLS)
+
+- 👍 Strong transport-layer identity; encryption and authentication combined
+- 👎 Certificate authority and per-service certificate lifecycle to manage;
+  heavy without a service mesh

--- a/docs/adr/0003-uuid-pk-for-users-bigint-elsewhere.md
+++ b/docs/adr/0003-uuid-pk-for-users-bigint-elsewhere.md
@@ -1,0 +1,68 @@
+# Use a UUID primary key for users, BIGINT identity elsewhere
+
+- Status: accepted
+- Date: 2026-06-06
+- Deciders: Eric Bouchut
+
+## Context and Problem Statement
+
+Every table needs a primary-key type. Sequential integer keys are enumerable:
+if exposed in a URL, API response, or token, they enable resource enumeration
+and make IDOR bugs trivial to exploit. UUID keys are non-enumerable but larger,
+and the random v4 variant hurts insert locality. The current frontend is
+Thymeleaf (server-rendered, ids not exposed), but a possible React/API
+version 2.0 after certification could expose the user id to clients. Which key
+type should each table use?
+
+## Decision Drivers
+
+- Avoid exposing enumerable identifiers for client-reachable resources
+- Insert and index efficiency on append-heavy internal tables
+- Forward compatibility with a potential React/API v2 (post-certification)
+- Keeping the entity/JPA layer reasonably simple
+
+## Considered Options
+
+- UUID primary key for all tables
+- BIGINT identity primary key for all tables
+- UUID for `users` only, BIGINT identity elsewhere (mixed)
+
+## Decision Outcome
+
+Chosen: **UUID for `users.user_id`, BIGINT identity for all other tables**.
+`user_id` is the only identifier exposed outside the database — as the session
+subject today, and potentially through a React/API v2 tomorrow — so it must be
+non-enumerable. Every other table is internal and never exposes its key, so a
+compact, sequentially-inserted BIGINT is the better physical choice.
+
+### Consequences
+
+- Good: user ids are non-enumerable and safe to expose now and for a future v2,
+  avoiding a costly user-id type migration later.
+- Good: internal tables keep small, sequential keys; token tables remain
+  protected by their random `token` column regardless of key type.
+- Trade-off: two id types coexist in the model; `audit_logs.entity_id` is stored
+  as text because it may reference a UUID (users) or a BIGINT (other tables);
+  FK columns to `users` are UUID while FKs to other tables are BIGINT.
+- Note: `gen_random_uuid()` (UUIDv4) is used; revisit UUIDv7 for better insert
+  locality if user write volume grows, or upon upgrading to PostgreSQL 18.
+
+## Pros and Cons of the Options
+
+### UUID for all tables
+
+- 👍 Uniform JPA model; every id non-enumerable
+- 👎 Larger keys/indexes on append-heavy tables (e.g. audit_logs); v4 randomness
+  hurts insert locality
+
+### BIGINT identity for all tables
+
+- 👍 Smallest and fastest; uniform; human-readable
+- 👎 Enumerable; exposing any id (especially the user id) invites enumeration and
+  IDOR; would later require a separate public id column
+
+### UUID for users only, BIGINT elsewhere (chosen)
+
+- 👍 Non-enumerable where it matters; compact keys elsewhere; future-API-safe
+  user id
+- 👎 Mixed id types; `entity_id` stored as text; mixed FK column types

--- a/docs/adr/0004-use-mailpit-as-local-smtp-catcher.md
+++ b/docs/adr/0004-use-mailpit-as-local-smtp-catcher.md
@@ -1,0 +1,62 @@
+# Use Mailpit as the local fake SMTP catcher
+
+- Status: accepted
+- Date: 2026-06-08
+- Deciders: Eric Bouchut
+
+## Context and Problem Statement
+
+Features such as password reset (#51) and email verification send email. During
+development and automated testing, these flows must be exercised without
+delivering real messages to real inboxes. We need a local "fake SMTP" catcher
+that traps outgoing mail for visual inspection and test assertions. Which tool
+should the project standardise on?
+
+## Decision Drivers
+
+- Active maintenance and project health
+- Quality of the inspection UI (search, HTML/source views)
+- A REST API usable for automated integration tests
+- Ease of running in Docker Compose alongside PostgreSQL
+- Zero impact on application code (standard SMTP)
+
+## Considered Options
+
+- Mailpit
+- MailHog
+
+## Decision Outcome
+
+Chosen: **Mailpit**. It is actively maintained, provides a modern UI with search
+and a clean REST API for test assertions, runs as a small container using the
+same SMTP/UI ports as MailHog, and requires no application changes (Spring simply
+points `spring.mail.*` at it). MailHog, while historically popular, is
+effectively unmaintained (last release 2020).
+
+### Consequences
+
+- Good: actively maintained; clean REST API enables end-to-end password-reset
+  integration tests; modern UI and SQLite persistence ease local debugging;
+  trivial Docker Compose service.
+- Good: no application coupling — only `spring.mail.*` differs between dev
+  (Mailpit) and production (a real provider).
+- Trade-off: Mailpit is not a production mail service; a real SMTP provider
+  (e.g. Amazon SES, Mailgun) is still required for production.
+- Note: this choice applies to local development and testing only; it is never
+  used in production.
+
+## Pros and Cons of the Options
+
+### Mailpit
+
+- 👍 Actively maintained; modern UI with search; clean REST API; SQLite
+  persistence; small image
+- 👎 Newer and less historically ubiquitous than MailHog
+
+### MailHog
+
+- 👍 Long-established and widely documented
+- 👎 Unmaintained since 2020; dated UI; weaker API tooling
+
+Spring configuration is identical for both (SMTP on `1025`), so there is no
+integration cost to choosing Mailpit.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,37 @@
+# Architecture Decision Records (ADR)
+
+This directory holds the **Architecture Decision Records** for learn-dev.
+
+An ADR is a short, dated document that captures one significant architectural or
+design decision — its context, the choice made, and its consequences. ADRs are
+an **append-only, numbered log**: a decision is never silently rewritten; when a
+choice changes, a new ADR *supersedes* the old one, preserving the history of
+*why* the system is the way it is.
+
+## Format
+
+All ADRs use the **MADR** (Markdown Any Decision Records) short form.
+Copy [`template.md`](template.md) when writing a new one.
+
+## Naming convention
+
+```
+NNNN-short-title-in-kebab-case.md
+```
+
+- `NNNN` — 4-digit zero-padded, sequential (`0001`, `0002`, …). Never reused.
+- Title — kebab-case, concise, topic-first.
+- Files are never deleted; a superseded ADR stays and its **Status** is updated.
+
+## Status values
+
+`proposed` · `accepted` · `superseded by ADR-NNNN` · `deprecated`
+
+## Index
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [0001](0001-use-server-side-sessions-over-jwt.md) | Use server-side sessions instead of JWT for user authentication | accepted |
+| [0002](0002-service-to-service-auth-via-service-token.md) | Authenticate service-to-service calls with a service token | proposed |
+| [0003](0003-uuid-pk-for-users-bigint-elsewhere.md) | Use a UUID primary key for users, BIGINT identity elsewhere | accepted |
+| [0004](0004-use-mailpit-as-local-smtp-catcher.md) | Use Mailpit as the local fake SMTP catcher | accepted |

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,41 @@
+# <short title of the decision>
+
+- Status: proposed | accepted | superseded by ADR-NNNN | deprecated
+- Date: YYYY-MM-DD
+- Deciders: Eric Bouchut
+
+## Context and Problem Statement
+
+What forces and constraints are at play? State the problem, ideally as a
+question. One or two short paragraphs.
+
+## Decision Drivers
+
+- <criterion that matters, e.g. security>
+- <criterion, e.g. setup cost>
+
+## Considered Options
+
+- Option A
+- Option B
+
+## Decision Outcome
+
+Chosen: "Option A", because <justification>.
+
+### Consequences
+
+- Good: <positive outcome>
+- Trade-off: <cost or downside>
+
+## Pros and Cons of the Options
+
+### Option A
+
+- 👍 <pro>
+- 👎 <con>
+
+### Option B
+
+- 👍 <pro>
+- 👎 <con>


### PR DESCRIPTION
This PR aims to set up a track record of `ADR` (*Architecture Decision Records*).
Architecture Decision Records (ADRs) are stored under `docs/adr`.

- Add a README file that explains ADR purpose and usage
- Add an ADR template to standardize ADR entries 
- Remove `learning assessment` references (descoped from v1.0).
  (fixes #50).
- Update `.gitignore` to exclude Claude tooling (`.mcp.json`),
  not to impose my personal Claude tooling preferences on the team.