### PR TITLE
docs: Address overlooked PR#66 review comments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ The code reference documentation is not yet available and will be added to this 
 
 #### Architecture Decision Records (ADR)
 
-Significant Architectural and design Decisions are Recorded as **ADRs** under
+Significant architectural and design decisions are recorded as **ADRs** under
 [`docs/adr/`](docs/adr/), as Markdown files using the **[MADR](https://adr.github.io/madr/)** structure. 
 ADRs are an append-only, numbered log: a decision is never rewritten.  
 A new ADR supersedes an old one.   

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ you can stop then restart the `mongo` service container individually.
 #### Stop MongoDB
 
 ```shell
-docker compose down mongo
+docker compose stop mongo
 ```
 This command stops the `mongo` service container.
 It does NOT remove its data volume (i.e., the MongoDB databases created in this container).

--- a/src/test/java/com/ericbouchut/learndev/role/repository/RoleRepositoryTest.java
+++ b/src/test/java/com/ericbouchut/learndev/role/repository/RoleRepositoryTest.java
@@ -10,9 +10,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  *
- * {@code @AutoConfigureTestDatabase(replace = NONE} prevents
+ * {@code @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)} prevents
  * the test from using a H2 embedded database.
- * We use containerized PostgresSQL database via {@link AbstractPostgresIT#POSTGRES}
+ * We use containerized PostgreSQL database via {@link AbstractPostgresIT#POSTGRES}
  * because we need to test against the real database schema and datatypes
  * that H2 does not support.
  */

--- a/src/test/java/com/ericbouchut/learndev/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/ericbouchut/learndev/user/repository/UserRepositoryTest.java
@@ -15,7 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 // - Tests are transactional and roll back by default
 @DataJpaTest
 // Do not perform tests against an in-memory H2 database but use the real one
-// defined in AbstractPostgresIT.POSTGRES annotated with @ServiceConnection and @Container
+// defined in AbstractPostgresIT.POSTGRES annotated with @ServiceConnection.
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class UserRepositoryTest extends AbstractPostgresIT {
 


### PR DESCRIPTION
Correct and clarify the DB test documents and commands that were unpushed in PR #66.