### PR TITLE
fix(ci): Bump GitHub actions to Node 24 releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "21"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,8 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "21"
@@ -29,7 +29,7 @@ jobs:
         run: ./mvnw -B -ntp checkstyle:checkstyle
       - name: Upload the Checkstyle report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: checkstyle-report
           path: target/checkstyle-result.xml

--- a/.github/workflows/schema-drift.yml
+++ b/.github/workflows/schema-drift.yml
@@ -23,8 +23,8 @@ jobs:
   schema-drift:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
       - name: Check MCD vs Liquibase column drift

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "21"
@@ -28,7 +28,7 @@ jobs:
       # produced the coverage report (HTML and XML).
       - name: Upload the coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: jacoco-coverage-report
           path: target/site/jacoco/


### PR DESCRIPTION
This PR fixes the CI.
It bumps every action in all workflows to its current major, which targets Node 24 natively:

- `actions/checkout` v4 => v7
- `actions/setup-java` v4 => v5
- `actions/upload-artifact` v4 => v7
- `actions/setup-python` v5 => v6


## Issue

Every GitHub Action workflow run logged a warning saying: 
> Node.js 20 is deprecated; the following actions target Node.js 20 but are being forced to run on Node.js 24 (actions/checkout@v4, actions/setup-java@v4). Bump all actions to their current majors, which target Node 24 natively.


## Cause

> GitHub deprecated Node.js 20 on Actions runners (September 2025). actions/checkout@v4 and actions/setup-java@v4 are built against Node 20, so every job now emits that annotation while being force-run on Node 24. Harmless today, but those majors will eventually stop working.
