### PR TITLE
docs(ci): Link the JaCoCo coverage reports from README and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -899,6 +899,22 @@ Make sure the Podman machine is started first: `podman machine start`.
 On real Docker (for example in CI) neither variable is needed; `make test`
 falls back to a plain `./mvnw test`.
 
+#### Test Coverage Report (JaCoCo)
+
+Every test run measures code coverage with [JaCoCo](https://www.jacoco.org/jacoco/)
+(see [ADR-0011](docs/adr/0011-start-ci-quality-checks-as-advisory-reports.md):
+coverage is reported, not yet enforced as a threshold).
+
+- **Locally**: `make test` (or `./mvnw test`) writes the report to
+  `target/site/jacoco/index.html`. Open it in a browser:
+  ```bash
+  open target/site/jacoco/index.html  # macOS
+  ```
+- **On CI**: every [Tests workflow run](https://github.com/ebouchut/learn-dev/actions/workflows/test.yml)
+  uploads the report as the **`jacoco-coverage-report`** artifact.
+  Open a run, scroll to its **Artifacts** section, download the archive,
+  and open `index.html` inside it.
+
 
 ### Generating the Documentation
 

--- a/README.md
+++ b/README.md
@@ -378,6 +378,10 @@ visit [this link](https://github.com/users/ebouchut/projects/7/views/3).
 - [GLOSSARY.md](GLOSSARY.md) — definitions of the domain and technical terms used across the project
   (🇫🇷 French version: [GLOSSAIRE.md](GLOSSAIRE.md)).
 - [Architecture Decision Records](docs/adr/README.md) — A list of design decisions and their trade-offs.
+- [Test coverage reports (JaCoCo)](https://github.com/ebouchut/learn-dev/actions/workflows/test.yml) —
+  published as the `jacoco-coverage-report` artifact of each Tests workflow run;
+  locally, `make test` writes the same report to `target/site/jacoco/index.html`
+  (see [CONTRIBUTING](CONTRIBUTING.md#test-coverage-report-jacoco) for details).
 
 
 ## Contributing


### PR DESCRIPTION
This PR:
- adds a `Test Coverage Report` subsection to the `Running Tests` section of
CONTRIBUTING.md explaining where the JaCoCo (Java Code Coverage) report lands:
    - locally
(`target/site/jacoco/index.html`) after `make test`
    - on CI (the`jacoco-coverage-report` artifact of each Tests workflow run),
- reference the test coverage report in the README