### PR TITLE
ci: Add a link to CheckStyle (lint) report

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,9 +27,13 @@ jobs:
           cache: maven
       - name: Generate the Checkstyle report
         run: ./mvnw -B -ntp checkstyle:checkstyle
+      # The artifact ships the browsable HTML report (target/reports/,
+      # with its css/fonts/images assets) plus the raw XML result.
       - name: Upload the Checkstyle report
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: checkstyle-report
-          path: target/checkstyle-result.xml
+          path: |
+            target/reports/
+            target/checkstyle-result.xml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -775,7 +775,31 @@ chore(git): Ignore IntelliJ IDEA configuration files
 
 ### Code Style and Formatting
 
-: Document the code style and formatting
+- **Java**: standard 4-space indentation. The style is checked by
+  **Checkstyle** against the project ruleset
+  [`config/checkstyle/checkstyle.xml`](config/checkstyle/checkstyle.xml),
+  a copy of the Google ruleset adapted to this project's conventions
+  (4-space indentation, IDE-managed import order; the adaptations are
+  documented in the file header). Checks are **advisory** for now: see
+  [ADR-0012](docs/adr/0012-publish-test-coverage-to-codecov.md), which
+  restates the advisory-lint stance of
+  [ADR-0011](docs/adr/0011-start-ci-quality-checks-as-advisory-reports.md).
+- **HTML/CSS**: 2-space indentation (the convention used by the Thymeleaf
+  templates in `src/main/resources/templates/`).
+
+#### Checkstyle Report
+
+- **Locally**: run the check and open the browsable report:
+  ```bash
+  ./mvnw -B checkstyle:checkstyle
+  open target/reports/checkstyle.html  # macOS
+  ```
+  Violations also print on the console as warnings, and the raw XML result
+  is written to `target/checkstyle-result.xml`.
+- **On CI**: every [Lint workflow run](https://github.com/ebouchut/learn-dev/actions/workflows/lint.yml)
+  uploads both as the **`checkstyle-report`** artifact.
+  Open a run, scroll to its **Artifacts** section, download the archive,
+  and open `reports/checkstyle.html` inside it.
 
 
 ### Reset the Development Database

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![build status][build-image]][build-url]
 [![test status][test-image]][test-url]
 [![code coverage][coverage-image]][coverage-url]
-[![lint status][lint-image]][lint-url]
+[![lint status][lint-image]][lint-url][![lint report][lint-report-image]][lint-report-url]
 [![schema drift status][schema-drift-image]][schema-drift-url]
 [![github issues][github-issues-image]][github-issues-url]
 
@@ -388,6 +388,8 @@ visit [this link](https://github.com/users/ebouchut/projects/7/views/3).
   (see [CONTRIBUTING](CONTRIBUTING.md#test-coverage-report-jacoco) for details).
 - [Code quality report (Checkstyle)](https://github.com/ebouchut/learn-dev/actions/workflows/lint.yml) —
   published as the `checkstyle-report` artifact of each Lint workflow run;
+  [download the latest report directly](https://nightly.link/ebouchut/learn-dev/workflows/lint/dev/checkstyle-report.zip)
+  (a zip served by nightly.link; open `reports/checkstyle.html` inside);
   locally, `./mvnw checkstyle:checkstyle` writes `target/reports/checkstyle.html`
   (see [CONTRIBUTING](CONTRIBUTING.md#code-style-and-formatting) for the code style).
 
@@ -462,6 +464,8 @@ See [LICENSE](LICENSE) for details.
 [coverage-url]:   https://app.codecov.io/gh/ebouchut/learn-dev
 [lint-image]:  https://github.com/ebouchut/learn-dev/actions/workflows/lint.yml/badge.svg?branch=dev&event=push
 [lint-url]:    https://github.com/ebouchut/learn-dev/actions/workflows/lint.yml
+[lint-report-image]: https://img.shields.io/badge/-report-blue
+[lint-report-url]:   https://nightly.link/ebouchut/learn-dev/workflows/lint/dev/checkstyle-report.zip
 [schema-drift-image]: https://github.com/ebouchut/learn-dev/actions/workflows/schema-drift.yml/badge.svg?branch=dev&event=push
 [schema-drift-url]:   https://github.com/ebouchut/learn-dev/actions/workflows/schema-drift.yml
 [github-issues-image]: https://img.shields.io/github/issues/ebouchut/learn-dev

--- a/README.md
+++ b/README.md
@@ -386,6 +386,10 @@ visit [this link](https://github.com/users/ebouchut/projects/7/views/3).
   artifact of each [Tests workflow run](https://github.com/ebouchut/learn-dev/actions/workflows/test.yml),
   and locally `make test` writes it to `target/site/jacoco/index.html`
   (see [CONTRIBUTING](CONTRIBUTING.md#test-coverage-report-jacoco) for details).
+- [Code quality report (Checkstyle)](https://github.com/ebouchut/learn-dev/actions/workflows/lint.yml) —
+  published as the `checkstyle-report` artifact of each Lint workflow run;
+  locally, `./mvnw checkstyle:checkstyle` writes `target/reports/checkstyle.html`
+  (see [CONTRIBUTING](CONTRIBUTING.md#code-style-and-formatting) for the code style).
 
 
 ## Contributing


### PR DESCRIPTION
Make the CI Checkstyle report easy to find, mirroring the coverage links.

- The Lint workflow now uploads the *CheckStyle* browsable **HTML** report (`reports/checkstyle.html`) alongside the raw XML in the `checkstyle-report` artifact.
- **Docs**: fills the `Code Style and Formatting` stub in `CONTRIBUTING.md` (Java 4-space + project Checkstyle ruleset, HTML/CSS 2-space, advisory per [ADR-0012](docs/adr/0012-publish-test-coverage-to-codecov.md)) with a `Checkstyle Report` subsection (local paths + CI artifact); adds a `Code quality report` entry to the README documentation list.
- Add a new **`report` badge** to `README.md`. When clicked, it downloads the **latest** CheckStyle report (in HTML format). 
  It uses [nightly.link](https://nightly.link/ebouchut/learn-dev/workflows/lint/dev/checkstyle-report.zip), a free online artifact proxy service. 



