### PR TITLE
ci: Publish Checkstyle report to GitHub Pages

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,10 +1,12 @@
 name: Lint
 
-# Code quality check (Checkstyle, Google ruleset) on every PR and push.
+# Code quality check (Checkstyle, project ruleset) on every PR and push.
 # Deliberately non-blocking on day one for an existing codebase:
 #   - checkstyle:checkstyle only generates a report, it never fails on violations
 #   - continue-on-error keeps even setup errors from gating merges
-# The report is uploaded as a workflow artifact for review.
+# The report is uploaded as a workflow artifact for review, and on pushes
+# to dev it is also published to GitHub Pages (rendered HTML, no download):
+# the official upload-pages-artifact + deploy-pages flow creates no commits.
 # Tighten later: switch the goal to checkstyle:check and set
 # failOnViolation to true in pom.xml, then drop continue-on-error.
 
@@ -37,3 +39,45 @@ jobs:
           path: |
             target/reports/
             target/checkstyle-result.xml
+      # On pushes to dev, publish the HTML report online via GitHub Pages.
+      # The site is namespaced under /checkstyle/ so future reports can
+      # join under their own paths without breaking URLs.
+      - name: Assemble the Pages site
+        if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
+        run: |
+          mkdir -p _site/checkstyle
+          cp -R target/reports/. _site/checkstyle/
+          cat > _site/index.html <<'HTML'
+          <!DOCTYPE html>
+          <html lang="en">
+            <head>
+              <meta charset="UTF-8">
+              <meta http-equiv="refresh" content="0; url=checkstyle/checkstyle.html">
+              <title>learn-dev reports</title>
+            </head>
+            <body>
+              <p><a href="checkstyle/checkstyle.html">Checkstyle report</a></p>
+            </body>
+          </html>
+          HTML
+      - name: Upload the Pages artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: _site
+
+  # Deploys the assembled site (no commits: Pages serves the artifact).
+  deploy-report:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
+    needs: checkstyle
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -796,6 +796,9 @@ chore(git): Ignore IntelliJ IDEA configuration files
   ```
   Violations also print on the console as warnings, and the raw XML result
   is written to `target/checkstyle-result.xml`.
+- **Online**: the latest report from `dev` is
+  [rendered on GitHub Pages](https://www.ericbouchut.com/learn-dev/checkstyle/checkstyle.html)
+  (republished by the Lint workflow on each merge to `dev`, without any commit).
 - **On CI**: every [Lint workflow run](https://github.com/ebouchut/learn-dev/actions/workflows/lint.yml)
   uploads both as the **`checkstyle-report`** artifact.
   Open a run, scroll to its **Artifacts** section, download the archive,

--- a/README.md
+++ b/README.md
@@ -386,10 +386,10 @@ visit [this link](https://github.com/users/ebouchut/projects/7/views/3).
   artifact of each [Tests workflow run](https://github.com/ebouchut/learn-dev/actions/workflows/test.yml),
   and locally `make test` writes it to `target/site/jacoco/index.html`
   (see [CONTRIBUTING](CONTRIBUTING.md#test-coverage-report-jacoco) for details).
-- [Code quality report (Checkstyle)](https://github.com/ebouchut/learn-dev/actions/workflows/lint.yml) —
-  published as the `checkstyle-report` artifact of each Lint workflow run;
-  [download the latest report directly](https://nightly.link/ebouchut/learn-dev/workflows/lint/dev/checkstyle-report.zip)
-  (a zip served by nightly.link; open `reports/checkstyle.html` inside);
+- [Code quality report (Checkstyle)](https://www.ericbouchut.com/learn-dev/checkstyle/checkstyle.html) —
+  the latest report, rendered online via GitHub Pages (refreshed on each merge to `dev`);
+  also published as the `checkstyle-report` artifact of each
+  [Lint workflow run](https://github.com/ebouchut/learn-dev/actions/workflows/lint.yml);
   locally, `./mvnw checkstyle:checkstyle` writes `target/reports/checkstyle.html`
   (see [CONTRIBUTING](CONTRIBUTING.md#code-style-and-formatting) for the code style).
 
@@ -465,7 +465,7 @@ See [LICENSE](LICENSE) for details.
 [lint-image]:  https://github.com/ebouchut/learn-dev/actions/workflows/lint.yml/badge.svg?branch=dev&event=push
 [lint-url]:    https://github.com/ebouchut/learn-dev/actions/workflows/lint.yml
 [lint-report-image]: https://img.shields.io/badge/-report-blue
-[lint-report-url]:   https://nightly.link/ebouchut/learn-dev/workflows/lint/dev/checkstyle-report.zip
+[lint-report-url]:   https://www.ericbouchut.com/learn-dev/checkstyle/checkstyle.html
 [schema-drift-image]: https://github.com/ebouchut/learn-dev/actions/workflows/schema-drift.yml/badge.svg?branch=dev&event=push
 [schema-drift-url]:   https://github.com/ebouchut/learn-dev/actions/workflows/schema-drift.yml
 [github-issues-image]: https://img.shields.io/github/issues/ebouchut/learn-dev


### PR DESCRIPTION
The rationale for this PR is to **enable viewing** the **CheckStyle** (lint) HTML **report online** when clicking the `report` badge in the `README.md` file.

This PR brings the following:
- Publish Checkstyle HTML report to GitHub Pages on pushes to dev,
  - Deploys a site using upload-artifact and deploy-pages actions without commits
- Keep artifact available for PR runs
    - online report updates on each merge to dev
- Update docs and links to point to the GitHub Pages report, while documenting artifact and local paths for PR/offline use.