### PR TITLE
feat(markdown): Render lesson Markdown to sanitized, cached HTML

### DIFF
--- a/GLOSSAIRE.md
+++ b/GLOSSAIRE.md
@@ -121,6 +121,10 @@ pour la justification des décisions de conception, voir les [ADR](docs/adr/READ
 - **Bean Validation** — Le standard Jakarta de déclaration de contraintes
   (`@NotBlank`, `@Email`, `@Size`) sur les champs de formulaires/DTO,
   appliquées avec `@Valid`.
+- **Caffeine** — Une bibliothèque de cache en mémoire très performante pour
+  Java. Utilisée derrière l'abstraction de cache de Spring (`@Cacheable`)
+  pour conserver le HTML des leçons rendues, plafonnée à 1000 entrées (voir
+  [ADR-0013](docs/adr/0013-render-lesson-markdown-with-commonmark-java.md)).
 - **Checkstyle** — Un outil d'analyse statique qui vérifie les sources Java
   contre un référentiel de style. Exécuté ici avec le référentiel Google
   fourni (`google_checks.xml`) en mode rapport seul (voir
@@ -133,6 +137,10 @@ pour la justification des décisions de conception, voir les [ADR](docs/adr/READ
   commente chaque PR avec la couverture du projet et du patch. Les statuts
   sont informatifs ici (voir
   [ADR-0012](docs/adr/0012-publish-test-coverage-to-codecov.md)).
+- **CommonMark** — Une spécification stricte et non ambiguë de Markdown, et
+  par extension son implémentation Java de référence (commonmark-java), qui
+  convertit le Markdown des leçons en HTML (voir
+  [ADR-0013](docs/adr/0013-render-lesson-markdown-with-commonmark-java.md)).
 - **DTO (Data Transfer Object)** — Un objet qui transporte des données à
   travers une frontière, volontairement distinct des entités. Un DTO `...Form`
   porte un formulaire HTML.
@@ -150,6 +158,11 @@ pour la justification des décisions de conception, voir les [ADR](docs/adr/READ
   Son plugin Maven instrumente les tests (`prepare-agent`) et écrit un rapport
   HTML/XML dans `target/site/jacoco/` pendant la phase `test` ; la CI le
   publie comme artefact de workflow.
+- **jsoup** — Un parseur et assainisseur HTML pour Java. Sa liste
+  d'autorisation `Safelist` retire le balisage dangereux (scripts,
+  gestionnaires d'événements, cadres) du HTML des leçons rendues : une
+  défense XSS qui ne repose pas sur la confiance envers les auteurs (voir
+  [ADR-0013](docs/adr/0013-render-lesson-markdown-with-commonmark-java.md)).
 - **Linter** — Un outil qui signale les problèmes de style et de qualité dans
   le code source sans l'exécuter (analyse statique). Le linter du projet est
   Checkstyle.
@@ -157,6 +170,9 @@ pour la justification des décisions de conception, voir les [ADR](docs/adr/READ
   constructeurs) à partir d'annotations, à la compilation.
 - **MADR (Markdown ADR)** — Le format léger de modèle d'ADR utilisé dans
   `docs/adr/`.
+- **Markdown** — Un format de balisage léger en texte brut. Le contenu des
+  leçons est rédigé en Markdown (la colonne `content_markdown`) et rendu en
+  HTML assaini au moment de l'affichage.
 - **Maven Wrapper (`mvnw`)** — Un script de lancement versionné qui télécharge
   et exécute la version de Maven épinglée par le projet, pour que les builds
   ne dépendent pas d'un Maven installé localement (utilisé par la CI :

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -101,6 +101,10 @@ rationale behind design decisions, see the [ADRs](docs/adr/README.md).
   capturing one design decision and its trade-offs, in MADR format.
 - **Bean Validation** — The Jakarta standard for declaring constraints
   (`@NotBlank`, `@Email`, `@Size`) on form/DTO fields, enforced with `@Valid`.
+- **Caffeine** — A high-performance in-memory cache library for Java. Used
+  behind Spring's cache abstraction (`@Cacheable`) to hold rendered lesson
+  HTML, capped at 1000 entries (see
+  [ADR-0013](docs/adr/0013-render-lesson-markdown-with-commonmark-java.md)).
 - **Checkstyle** — A static-analysis tool that checks Java source against a
   style ruleset. Runs here with the bundled Google ruleset (`google_checks.xml`)
   in report-only mode (see [ADR-0011](docs/adr/0011-start-ci-quality-checks-as-advisory-reports.md)).
@@ -111,6 +115,10 @@ rationale behind design decisions, see the [ADRs](docs/adr/README.md).
   renders a dashboard and a README badge, and comments on PRs with the
   project and patch coverage. Statuses are informational here (see
   [ADR-0012](docs/adr/0012-publish-test-coverage-to-codecov.md)).
+- **CommonMark** — A strict, unambiguous specification of Markdown, and by
+  extension its reference Java implementation (commonmark-java), which
+  converts lesson Markdown to HTML (see
+  [ADR-0013](docs/adr/0013-render-lesson-markdown-with-commonmark-java.md)).
 - **DTO (Data Transfer Object)** — An object carrying data across a boundary,
   deliberately separate from entities. A `...Form` DTO backs an HTML form.
 - **Failsafe** — The Maven plugin that runs `*IT` integration tests in the `verify`
@@ -123,11 +131,18 @@ rationale behind design decisions, see the [ADRs](docs/adr/README.md).
 - **JaCoCo (Java Code Coverage)** — The code-coverage tool for Java. Its Maven
   plugin instruments the tests (`prepare-agent`) and writes an HTML/XML report to
   `target/site/jacoco/` during the `test` phase; CI uploads it as a workflow artifact.
+- **jsoup** — A Java HTML parser and sanitizer. Its `Safelist` allowlist
+  strips dangerous markup (scripts, event handlers, frames) from the rendered
+  lesson HTML: XSS defense that does not depend on trusting authors (see
+  [ADR-0013](docs/adr/0013-render-lesson-markdown-with-commonmark-java.md)).
 - **Linter** — A tool that flags style and quality issues in source code without
   running it (static analysis). The project's linter is Checkstyle.
 - **Lombok** — A library that generates boilerplate (getters, constructors) from
   annotations at compile time.
 - **MADR (Markdown ADR)** — The lightweight ADR template format used in `docs/adr/`.
+- **Markdown** — A lightweight plain-text markup format. Lesson content is
+  authored in Markdown (the `content_markdown` column) and rendered to
+  sanitized HTML at display time.
 - **Maven Wrapper (`mvnw`)** — A committed launcher script that downloads and runs
   the project's pinned Maven version, so builds do not depend on a locally
   installed Maven (used by CI: `./mvnw -B -ntp ...`).

--- a/docs/adr/0013-render-lesson-markdown-with-commonmark-java.md
+++ b/docs/adr/0013-render-lesson-markdown-with-commonmark-java.md
@@ -1,0 +1,79 @@
+# Render lesson Markdown with commonmark-java, sanitized by jsoup
+
+- Status: accepted
+- Date: 2026-07-11
+- Deciders: Eric Bouchut
+
+## Context and Problem Statement
+
+Lesson content (issue #34) is authored in Markdown (`lessons.content_markdown`)
+and must reach the browser as HTML. The converter choice (issue #35) shapes
+security and performance: lesson Markdown is instructor input, so the rendered
+HTML is an XSS vector if served unsanitized; and lessons are read far more
+often than they change, so re-rendering on every view is wasted work
+(issue #38). Which Markdown library converts lesson content, and how are its
+output and its cost kept under control?
+
+## Decision Drivers
+
+- Security first: instructor-authored content must not be able to inject
+  scripts (XSS), whatever the Markdown contains
+- Spec compliance: predictable rendering of the common Markdown constructs
+- Small dependency surface, maintained library, permissive license
+- Cheap repeated reads: render once per content version, then serve from memory
+- Stay in the JVM: no extra runtime or service for v1
+
+## Considered Options
+
+- commonmark-java (CommonMark reference implementation) plus jsoup sanitizing
+- flexmark-java (feature-rich implementation with many extensions)
+- Server-side JavaScript renderer (markdown-it under GraalVM or Node)
+
+## Decision Outcome
+
+Chosen: "commonmark-java plus jsoup sanitizing", because commonmark-java is
+the reference implementation of the CommonMark spec: small, without
+transitive dependencies, fast, and BSD-2-Clause licensed; v1 needs none of
+flexmark's extension zoo. Raw HTML embedded in Markdown passes through the
+renderer by design, so sanitization is not optional: the rendered HTML goes
+through jsoup's `Safelist.relaxed()` allowlist (plus the `class` attribute on
+`code` to keep language hints), which strips scripts, event handlers, and
+frames no matter what the source says.
+
+Rendered HTML is cached with Spring Cache over Caffeine (Boot-managed
+version), keyed by the SHA-256 hash of the Markdown source: a
+content-addressed key cannot go stale (edited content is a new key), so no
+invalidation logic exists at all, and a 1000-entry bound caps memory. The
+Redis option (issue #40) stays deferred; swapping the cache backend later
+would not touch the renderer.
+
+### Consequences
+
+- Good: XSS defense is structural (an allowlist), not reliant on authors
+- Good: repeated lesson reads cost a hash lookup, not a parse and render
+- Good: three small libraries; Caffeine is version-managed by Spring Boot
+- Trade-off: GFM extensions (tables, strikethrough) need their own
+  `commonmark-ext-*` artifacts when a lesson actually needs them
+- Trade-off: the allowlist is stricter than raw CommonMark output
+  (for example relative links and images are dropped)
+- Neutral: cache entries are in-memory; an application restart clears them
+
+## Pros and Cons of the Options
+
+### commonmark-java plus jsoup
+
+- 👍 Reference implementation of the CommonMark spec; tiny and dependency-free
+- 👍 BSD-2-Clause; actively maintained
+- 👍 jsoup's Safelist is a battle-tested HTML allowlist
+- 👎 Extensions (GFM tables, strikethrough) are separate artifacts, added on
+  demand
+
+### flexmark-java
+
+- 👍 The most complete extension set (GFM, footnotes, TOC, admonitions)
+- 👎 Large dependency tree and API surface for needs v1 does not have
+
+### Server-side JavaScript renderer
+
+- 👍 The same renderer as many editors (markdown-it)
+- 👎 A second runtime to operate and secure; disproportionate for v1

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -43,3 +43,4 @@ NNNN-short-title-in-kebab-case.md
 | [0010](0010-structure-ci-as-focused-workflows-per-concern.md) | Structure CI as focused workflows per concern, not a monolithic ci.yml | accepted |
 | [0011](0011-start-ci-quality-checks-as-advisory-reports.md) | Start CI quality checks as advisory reports, gates come later | superseded by ADR-0012 |
 | [0012](0012-publish-test-coverage-to-codecov.md) | Publish test coverage to Codecov | accepted |
+| [0013](0013-render-lesson-markdown-with-commonmark-java.md) | Render lesson Markdown with commonmark-java, sanitized by jsoup | accepted |

--- a/docs/tech-stacks.md
+++ b/docs/tech-stacks.md
@@ -35,6 +35,14 @@ definitions see [GLOSSARY.md](../GLOSSARY.md).
 | thymeleaf-extras-springsecurity6 | via Boot | `sec:` dialect to read the authenticated user in templates. |
 | HTML / CSS / JavaScript | — | Front-end markup, styling, and behaviour. |
 
+## Content rendering
+
+| Technology | Version | Why here |
+|------------|---------|----------|
+| commonmark-java | 0.24.0 | Converts lesson Markdown to HTML (CommonMark reference implementation). See [ADR-0013](adr/0013-render-lesson-markdown-with-commonmark-java.md). |
+| jsoup | 1.21.1 | Sanitizes the rendered HTML against an allowlist (XSS defense). |
+| Spring Cache + Caffeine | via Boot | Caches rendered lesson HTML, keyed by content hash. |
+
 ## Persistence and data
 
 | Technology | Version | Why here |

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,8 @@
         <spring-dotenv.version>5.1.0</spring-dotenv.version>
         <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
         <jacoco-maven-plugin.version>0.8.15</jacoco-maven-plugin.version>
+        <commonmark.version>0.24.0</commonmark.version>
+        <jsoup.version>1.21.1</jsoup.version>
     </properties>
 
     <dependencies>
@@ -124,6 +126,26 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-mail</artifactId>
+        </dependency>
+
+        <!-- Lesson Markdown to sanitized, cached HTML (ADR-0013) -->
+        <dependency>
+            <groupId>org.commonmark</groupId>
+            <artifactId>commonmark</artifactId>
+            <version>${commonmark.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
+            <version>${jsoup.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-cache</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
         </dependency>
 
         <!-- Testcontainers: real PostgreSQL for repository/integration tests -->

--- a/src/main/java/com/ericbouchut/learndev/common/config/CacheConfig.java
+++ b/src/main/java/com/ericbouchut/learndev/common/config/CacheConfig.java
@@ -1,0 +1,28 @@
+package com.ericbouchut.learndev.common.config;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * In-memory caching (Spring Cache over Caffeine), currently holding rendered
+ * lesson HTML (see ADR-0013 in docs/adr/).
+ */
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    public static final String RENDERED_MARKDOWN_CACHE = "renderedMarkdown";
+
+    // Entries are content-addressed (SHA-256 keys), so they never go stale;
+    // the only pressure is memory, capped by entry count with LRU eviction.
+    @Bean
+    public CacheManager cacheManager() {
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager(RENDERED_MARKDOWN_CACHE);
+        cacheManager.setCaffeine(Caffeine.newBuilder().maximumSize(1_000));
+        return cacheManager;
+    }
+}

--- a/src/main/java/com/ericbouchut/learndev/course/MarkdownRenderer.java
+++ b/src/main/java/com/ericbouchut/learndev/course/MarkdownRenderer.java
@@ -1,0 +1,60 @@
+package com.ericbouchut.learndev.course;
+
+import com.ericbouchut.learndev.common.config.CacheConfig;
+import org.commonmark.parser.Parser;
+import org.commonmark.renderer.html.HtmlRenderer;
+import org.jsoup.Jsoup;
+import org.jsoup.safety.Safelist;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+/**
+ * Converts lesson Markdown to HTML that is safe to serve.
+ * <p>Lesson content is instructor input and CommonMark passes raw HTML
+ * through, so the rendered output is sanitized against an allowlist: no
+ * script, event handler, or frame survives, whatever the Markdown contains.
+ * Results are cached by the SHA-256 of the source, so a lesson is rendered
+ * once per content version (see ADR-0013 in docs/adr/).
+ */
+@Service
+public class MarkdownRenderer {
+
+    // The class attribute on code keeps CommonMark's language-* hints
+    // (```java fences) available to a future syntax highlighter.
+    private static final Safelist SAFELIST = Safelist.relaxed()
+            .addAttributes("code", "class");
+
+    private final Parser parser = Parser.builder().build();
+    private final HtmlRenderer renderer = HtmlRenderer.builder().build();
+
+    @Cacheable(cacheNames = CacheConfig.RENDERED_MARKDOWN_CACHE,
+            key = "T(com.ericbouchut.learndev.course.MarkdownRenderer).cacheKey(#markdown)")
+    public String render(String markdown) {
+        if (markdown == null || markdown.isBlank()) {
+            return "";
+        }
+        String html = renderer.render(parser.parse(markdown));
+        return Jsoup.clean(html, SAFELIST);
+    }
+
+    /**
+     * Cache key: SHA-256 of the source. Content-addressed, so edited content
+     * is a new key and stale entries cannot exist; the fixed-size key also
+     * avoids holding whole lesson sources in the cache's key set.
+     */
+    public static String cacheKey(String markdown) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(
+                    (markdown == null ? "" : markdown).getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 unavailable", e);
+        }
+    }
+}

--- a/src/test/java/com/ericbouchut/learndev/course/MarkdownRendererTest.java
+++ b/src/test/java/com/ericbouchut/learndev/course/MarkdownRendererTest.java
@@ -1,0 +1,72 @@
+package com.ericbouchut.learndev.course;
+
+import com.ericbouchut.learndev.common.config.CacheConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Boots a minimal context (just the cache config and the renderer, no
+ * database) so {@code @Cacheable} runs through the real Spring proxy.
+ */
+@SpringBootTest(classes = {CacheConfig.class, MarkdownRenderer.class})
+class MarkdownRendererTest {
+
+    @Autowired
+    MarkdownRenderer markdownRenderer;
+
+    @Test
+    void renders_markdown_constructs_to_html() {
+        // Arrange (Given): a lesson snippet with a heading, emphasis, and code
+        String markdown = "# Indexes\n\nSome **bold** text.\n\n```java\nint x = 1;\n```";
+
+        // Act (When)
+        String html = markdownRenderer.render(markdown);
+
+        // Assert (Then): structural HTML with the language hint preserved
+        assertThat(html).contains("<h1>Indexes</h1>");
+        assertThat(html).contains("<strong>bold</strong>");
+        assertThat(html).contains("<code class=\"language-java\">");
+    }
+
+    @Test
+    void strips_scripts_and_event_handlers_from_hostile_markdown() {
+        // Arrange (Given): raw HTML in Markdown passes through CommonMark,
+        // so only the sanitizer stands between this and the browser
+        String hostile = "Hello <script>alert('xss')</script>\n\n"
+                + "<img src=\"x\" onerror=\"alert(1)\">\n\n"
+                + "<a href=\"javascript:alert(2)\">click</a>";
+
+        // Act (When)
+        String html = markdownRenderer.render(hostile);
+
+        // Assert (Then): nothing executable survives the allowlist
+        assertThat(html).doesNotContain("<script");
+        assertThat(html).doesNotContain("onerror");
+        assertThat(html).doesNotContain("javascript:");
+        assertThat(html).contains("Hello");
+    }
+
+    @Test
+    void same_content_is_rendered_once_and_served_from_the_cache() {
+        // Arrange (Given): one Markdown source rendered twice
+        String markdown = "Cache **me** once.";
+
+        // Act (When)
+        String first = markdownRenderer.render(markdown);
+        String second = markdownRenderer.render(markdown);
+
+        // Assert (Then): the second call returns the cached instance itself,
+        // proving the renderer did not run again
+        assertThat(second).isSameAs(first);
+        assertThat(markdownRenderer.render("Different content.")).isNotSameAs(first);
+    }
+
+    @Test
+    void blank_content_renders_to_an_empty_string() {
+        assertThat(markdownRenderer.render("")).isEmpty();
+        assertThat(markdownRenderer.render("   ")).isEmpty();
+    }
+}


### PR DESCRIPTION


<!-- GitButler Footer Boundary Top -->
---
This is **part 5 of 5 in a stack** made with GitButler:
- <kbd>&nbsp;5&nbsp;</kbd> #90 (This PR)
- <kbd>&nbsp;4&nbsp;</kbd> #89
- <kbd>&nbsp;3&nbsp;</kbd> #88
- <kbd>&nbsp;2&nbsp;</kbd> #87
- <kbd>&nbsp;1&nbsp;</kbd> #86
<!-- GitButler Footer Boundary Bottom -->