### PR TITLE
docs: Catch the top-level docs up with the course stage

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -44,13 +44,16 @@ controller, service, entity, and repository live together:
 
 ```
 com.ericbouchut.learndev
+├── admin     # AdminController, AccountAdminService: accounts and content moderation
 ├── audit     # AuditService, entity/AuditLog: security audit trail (audit_logs)
 ├── auth      # AuthController, RegistrationService, CustomUserDetailsService,
 │             # PasswordResetController/Service/Mailer, entity/PasswordResetToken,
 │             # dto/*Form, exception/Duplicate*Exception
 ├── course    # entity/Course, Lesson, Enrollment (+EnrollmentId,
 │             # EnrollmentStatus, PublicationStatus), repository/*,
-│             # MarkdownRenderer (lesson Markdown to sanitized, cached HTML)
+│             # MarkdownRenderer (lesson Markdown to sanitized, cached HTML),
+│             # CourseController/DashboardController (student side),
+│             # InstructorCourseController (authoring), the course services
 ├── legal     # LegalController (privacy policy page)
 ├── user      # entity/User, repository/UserRepository
 ├── role      # entity/Role, repository/RoleRepository
@@ -161,10 +164,11 @@ as a static singleton container (see [ADR-0008](docs/adr/0008-share-singleton-te
 
 ## Direction of travel
 
-- The course web layer on top of the shipped domain: student catalogue,
-  enrollment and lesson reading, instructor authoring and rosters, admin
-  account and content lifecycle (see
-  [docs/plans/2026-07-12-course-management-by-role.md](docs/plans/2026-07-12-course-management-by-role.md)).
+- Email verification (the `email_tokens` table and `users.is_verified` are
+  still dormant) and account lockout (`failed_login_attempts` is never
+  incremented).
+- Production packaging: an application container image and a hardened prod
+  profile (secure session cookie, real SMTP).
 - Possible extraction of microservices, with service-to-service authentication
   ([ADR-0002](docs/adr/0002-service-to-service-auth-via-service-token.md)).
 - A `SUPERADMIN` role (deferred under YAGNI; issue #65).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -330,6 +330,10 @@ learn-dev/
     │   ├── java/com/ericbouchut/learndev/
     │   │   ├── LearnDevApplication.java                  # Spring Boot entry point
     │   │   │
+    │   │   ├── admin/                                    # Administration area (/admin/**, ROLE_ADMIN)
+    │   │   │   ├── AdminController.java                  # Account list/creation, content moderation
+    │   │   │   └── AccountAdminService.java              # Instructor creation, archive/reactivate, guards
+    │   │   │
     │   │   ├── audit/                                    # Security audit trail (audit_logs table)
     │   │   │   ├── AuditService.java                     # Records auditable events (reset requests, ...)
     │   │   │   ├── entity/
@@ -338,7 +342,7 @@ learn-dev/
     │   │   │       └── AuditLogRepository.java
     │   │   │
     │   │   ├── auth/                                     # Authentication (registration, login, password reset)
-    │   │   │   ├── AuthController.java                   # Web pages: home, login, dashboard, register
+    │   │   │   ├── AuthController.java                   # Web pages: home, login, register
     │   │   │   ├── CustomUserDetailsService.java         # Loads user + roles from DB for Spring Security
     │   │   │   ├── PasswordResetController.java          # Forgot password and reset password pages
     │   │   │   ├── PasswordResetMailer.java              # Sends the reset link over SMTP
@@ -358,7 +362,31 @@ learn-dev/
     │   │   │
     │   │   ├── common/                                   # Concerns shared across features
     │   │   │   └── config/
-    │   │   │       └── SecurityConfig.java               # Spring Security filter chain, form login, PasswordEncoder
+    │   │   │       ├── CacheConfig.java                  # Caffeine cache (rendered lesson Markdown)
+    │   │   │       └── SecurityConfig.java               # Spring Security filter chain, role gates, PasswordEncoder
+    │   │   │
+    │   │   ├── course/                                   # Course domain and its web layers
+    │   │   │   ├── CourseController.java                 # Student catalogue, detail, lessons, enroll/drop
+    │   │   │   ├── CourseService.java                    # Student visibility rules (read side)
+    │   │   │   ├── DashboardController.java              # The student's courses (GET /dashboard)
+    │   │   │   ├── EnrollmentService.java                # Enroll/drop lifecycle (idempotent)
+    │   │   │   ├── InstructorCourseController.java       # Authoring area (/instructor/**, ROLE_INSTRUCTOR)
+    │   │   │   ├── InstructorCourseService.java          # Ownership, publish/archive/restore, reorder, roster
+    │   │   │   ├── MarkdownRenderer.java                 # Lesson Markdown to sanitized HTML (ADR-0013, ADR-0014)
+    │   │   │   ├── dto/
+    │   │   │   │   ├── CourseForm.java
+    │   │   │   │   └── LessonForm.java
+    │   │   │   ├── entity/
+    │   │   │   │   ├── Course.java                       # Maps to the courses table
+    │   │   │   │   ├── Enrollment.java                   # Join entity on the enrollments table
+    │   │   │   │   ├── EnrollmentId.java                 # (user, course) composite key
+    │   │   │   │   ├── EnrollmentStatus.java             # ENROLLED, IN_PROGRESS, COMPLETED, DROPPED
+    │   │   │   │   ├── Lesson.java                       # Maps to the lessons table
+    │   │   │   │   └── PublicationStatus.java            # DRAFT, PUBLISHED, ARCHIVED
+    │   │   │   └── repository/
+    │   │   │       ├── CourseRepository.java
+    │   │   │       ├── EnrollmentRepository.java
+    │   │   │       └── LessonRepository.java
     │   │   │
     │   │   ├── legal/                                    # Legal pages
     │   │   │   └── LegalController.java                  # Privacy policy page (French)
@@ -389,8 +417,22 @@ learn-dev/
     │       │   ├── css/                                  # Design system: base.css, theme and font stylesheets
     │       │   └── fonts/                                # Self-hosted webfonts (OFL license files alongside)
     │       └── templates/                                # Thymeleaf views (server-rendered HTML)
+    │           ├── admin/                                # Administration pages (accounts, moderation)
+    │           │   ├── courses.html
+    │           │   ├── user-form.html
+    │           │   └── users.html
+    │           ├── courses/                              # Student course pages
+    │           │   ├── catalog.html
+    │           │   ├── detail.html
+    │           │   └── lesson.html
+    │           ├── error/                                # Styled error pages (403, 404, 500)
     │           ├── fragments/
     │           │   └── layout.html                       # Shared head, header (nav), and footer fragments
+    │           ├── instructor/                           # Authoring pages
+    │           │   ├── course-form.html
+    │           │   ├── courses.html
+    │           │   ├── lesson-form.html
+    │           │   └── students.html
     │           ├── dashboard.html
     │           ├── forgot-password.html
     │           ├── home.html

--- a/README.md
+++ b/README.md
@@ -59,8 +59,11 @@ and [Thymeleaf](https://en.wikipedia.org/wiki/Thymeleaf) frontend.
 
 The frontend is **server-rendered**: there is no separate frontend application.
 
-- [Thymeleaf](https://www.thymeleaf.org/) templates rendered by the backend
-  (home, login, register, and dashboard pages)
+- [Thymeleaf](https://www.thymeleaf.org/) templates rendered by the backend:
+  public pages (home, login, register, privacy), the student area (dashboard,
+  course catalogue, course and lesson pages), the instructor authoring area
+  (courses, lessons, roster), the admin area (accounts, course moderation),
+  and styled error pages
 - [thymeleaf-extras-springsecurity6](https://github.com/thymeleaf/thymeleaf-extras-springsecurity)
   to display authentication data (such as the logged-in username) in the pages
 - Server-side form handling with bean validation (no JavaScript framework yet)
@@ -432,7 +435,9 @@ visit [this link](https://github.com/users/ebouchut/projects/7/views/3).
   (🇫🇷 French version: [GLOSSAIRE.md](GLOSSAIRE.md)).
 - [Architecture Decision Records](docs/adr/README.md) — A list of design decisions and their trade-offs.
 - [docs/rgaa.md](docs/rgaa.md) — accessibility (RGAA) criteria map: what is expected for the DWWM,
-  how and where each criterion is fulfilled.
+  how and where each criterion is fulfilled;
+  [docs/rgaa-audit.md](docs/rgaa-audit.md) is the tooled self-audit report
+  (Lighthouse, axe-core, keyboard walkthrough).
 - [Mockups and wireframes (Figma)](https://www.figma.com/design/2q1Rt5NGbQ1w8gRtRGoF4A) —
   read-only Figma file with the high-fidelity mockups (Catppuccin theme) and the
   low-fidelity wireframes of the frontend pages; the browsable HTML mockups and


### PR DESCRIPTION
This PR ensures that the docs stay up-to-date with the recent addition of the course.

**`README.md`**:
- now describes all pages (student, instructor, admin, and error pages),
- Links the RGAA self-audit report next to the criteria map.

**`CONTRIBUTING.md`**: Update the directory tree to add the admin and course packages, CacheConfig, and the admin, courses, error, and instructor template folders.
`AuthController` no longer claims the dashboard. 

**`ARCHITECTURE.md`** lists the admin package, completes the course
package entry, and points the direction of travel at e-mail
verification, account lockout, and production packaging.
