### PR TITLE
docs(design): Sync the HTML prototype with the new course UI

### DIFF
--- a/docs/design/mockups/course-pages-explained.md
+++ b/docs/design/mockups/course-pages-explained.md
@@ -1,0 +1,45 @@
+# The course and instructor mockups, explained
+
+Unlike the original four mockups (which preceded the Thymeleaf templates),
+these nine pages were added *after* the course UI shipped: they are the
+shipped templates frozen as static HTML with sample data, so the prototype
+stays a faithful, browsable snapshot of the real interface. The sync happens
+at stable UI milestones only, not per merged pull request.
+
+What each page snapshots, and the one thing worth noticing on it:
+
+- **courses.html** (student catalogue): each `course-card` carries the
+  "You are enrolled" marker inside `course-card__meta`, the state the
+  controller computes per card.
+- **course.html** (course detail): shown in the just-enrolled state, so the
+  success alert (`role="status"`) and the "Quit this course" form are both
+  visible. Enroll/quit are POST forms, never links: they change state.
+- **lesson.html**: the `<article>` holds what `MarkdownRenderer` outputs.
+  The instructor authored `# Why lists matter`, but it arrives as an `h2`:
+  headings are demoted one level at render time so the page keeps exactly
+  one `h1` (RGAA 9.1, [ADR-0014](../../adr/0014-demote-markdown-headings-in-lesson-rendering.md)).
+- **dashboard.html** (updated): the earlier stats-and-progress concept is
+  gone; the shipped dashboard lists the student's active enrollments with
+  status and enrollment date. Stats may return later; the mockup tracks what
+  is real.
+- **instructor-courses.html**: the authoring entry point lists all statuses
+  (Draft, Published, Archived), unlike the student catalogue.
+- **instructor-course-editor.html**: one page hosts the edit form, the
+  publication lifecycle actions (only the transitions the current status
+  allows are rendered), and lesson management. The per-lesson buttons carry a
+  `visually-hidden` suffix ("Move up: Loops without tears") so a screen
+  reader hears which lesson each button acts on, while sighted users read
+  the row.
+- **instructor-lesson-editor.html**: `textarea.form__input` is the Markdown
+  editor; the hint reminds authors that output is sanitized (ADR-0013).
+- **instructor-students.html**: the roster uses the `.table` block with a
+  `visually-hidden` caption; the Remove action only renders for enrollments
+  that can still be dropped.
+- **error.html**: the styled 404 that replaced the Whitelabel page; 403 and
+  500 use the same skeleton with different copy.
+
+Shared wiring on every page, inherited from the app templates: skip link
+targeting `main#main` with `tabindex="-1"` (explicit focus move), one `h1`,
+`aria-current="page"` on the active nav entry, and role-aware nav (the
+Instructor entry appears only on instructor pages, where an instructor is
+logged in).

--- a/docs/design/mockups/course.html
+++ b/docs/design/mockups/course.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Dashboard — learn-dev</title>
+  <title>Course — learn-dev</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:wght@400;700&family=Sora:wght@600;700&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
@@ -18,8 +18,8 @@
       <a class="site-header__brand" href="home.html">learn<span class="site-header__brand-mark">-dev</span></a>
       <nav class="site-header__nav" aria-label="Main">
         <ul class="nav__list">
-          <li><a class="nav__link" href="dashboard.html" aria-current="page">Dashboard</a></li>
-          <li><a class="nav__link" href="courses.html">Courses</a></li>
+          <li><a class="nav__link" href="dashboard.html">Dashboard</a></li>
+          <li><a class="nav__link" href="courses.html" aria-current="page">Courses</a></li>
           <li>
             <!-- Logout is a POST in the real app (CSRF); styled as a ghost button -->
             <form action="#" method="post">
@@ -32,26 +32,30 @@
   </header>
 
   <main class="site-main" id="main" tabindex="-1">
-    <h1 class="page-title">Welcome back, <strong>carol</strong> 👋</h1>
+    <p class="alert alert--success" role="status">
+      You are enrolled in this course.
+    </p>
 
-    <section aria-labelledby="courses-title">
-      <h2 id="courses-title">Your courses</h2>
+    <h1 class="page-title">Python for curious minds</h1>
+    <p class="course-card__meta">By demo-teacher</p>
 
-      <ul class="course-list">
-        <li class="course-card">
-          <h3 class="course-card__title"><a href="course.html">Python for curious minds</a></h3>
-          <p class="course-card__meta">Enrolled &middot; since 13 July 2026</p>
-        </li>
-        <li class="course-card">
-          <h3 class="course-card__title"><a href="course.html">Git from the ground up</a></h3>
-          <p class="course-card__meta">In progress &middot; since 2 July 2026</p>
-        </li>
-        <li class="course-card">
-          <h3 class="course-card__title"><a href="course.html">Accessible HTML and CSS</a></h3>
-          <p class="course-card__meta">Completed &middot; since 15 June 2026</p>
-        </li>
-      </ul>
+    <p>Loops, lists, and a taste of the standard library.</p>
+
+    <div>
+      <form action="#" method="post">
+        <button class="button button--ghost" type="submit">Quit this course</button>
+      </form>
+    </div>
+
+    <section aria-labelledby="lessons-title">
+      <h2 id="lessons-title">Lessons</h2>
+      <ol>
+        <li><a href="lesson.html">Lists in five minutes</a></li>
+        <li><a href="lesson.html">Loops without tears</a></li>
+      </ol>
     </section>
+
+    <p><a href="courses.html">Back to all courses</a></p>
   </main>
 
   <footer class="site-footer">

--- a/docs/design/mockups/courses.html
+++ b/docs/design/mockups/courses.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Dashboard — learn-dev</title>
+  <title>Courses — learn-dev</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:wght@400;700&family=Sora:wght@600;700&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
@@ -18,8 +18,8 @@
       <a class="site-header__brand" href="home.html">learn<span class="site-header__brand-mark">-dev</span></a>
       <nav class="site-header__nav" aria-label="Main">
         <ul class="nav__list">
-          <li><a class="nav__link" href="dashboard.html" aria-current="page">Dashboard</a></li>
-          <li><a class="nav__link" href="courses.html">Courses</a></li>
+          <li><a class="nav__link" href="dashboard.html">Dashboard</a></li>
+          <li><a class="nav__link" href="courses.html" aria-current="page">Courses</a></li>
           <li>
             <!-- Logout is a POST in the real app (CSRF); styled as a ghost button -->
             <form action="#" method="post">
@@ -32,26 +32,20 @@
   </header>
 
   <main class="site-main" id="main" tabindex="-1">
-    <h1 class="page-title">Welcome back, <strong>carol</strong> 👋</h1>
+    <h1 class="page-title">Courses</h1>
 
-    <section aria-labelledby="courses-title">
-      <h2 id="courses-title">Your courses</h2>
-
-      <ul class="course-list">
-        <li class="course-card">
-          <h3 class="course-card__title"><a href="course.html">Python for curious minds</a></h3>
-          <p class="course-card__meta">Enrolled &middot; since 13 July 2026</p>
-        </li>
-        <li class="course-card">
-          <h3 class="course-card__title"><a href="course.html">Git from the ground up</a></h3>
-          <p class="course-card__meta">In progress &middot; since 2 July 2026</p>
-        </li>
-        <li class="course-card">
-          <h3 class="course-card__title"><a href="course.html">Accessible HTML and CSS</a></h3>
-          <p class="course-card__meta">Completed &middot; since 15 June 2026</p>
-        </li>
-      </ul>
-    </section>
+    <ul class="course-list">
+      <li class="course-card">
+        <h2 class="course-card__title"><a href="course.html">Python for curious minds</a></h2>
+        <p class="course-card__meta">By demo-teacher <span>&middot; You are enrolled</span></p>
+        <p>Loops, lists, and a taste of the standard library.</p>
+      </li>
+      <li class="course-card">
+        <h2 class="course-card__title"><a href="course.html">Git from the ground up</a></h2>
+        <p class="course-card__meta">By demo-teacher</p>
+        <p>Commits, branches, and how to think in snapshots.</p>
+      </li>
+    </ul>
   </main>
 
   <footer class="site-footer">

--- a/docs/design/mockups/css/base.css
+++ b/docs/design/mockups/css/base.css
@@ -136,6 +136,12 @@ code {
   top: 0;
 }
 
+/* The skip link moves focus onto main (tabindex="-1"); no ring on a
+   non-interactive landmark (WCAG 2.4.7 applies to interactive controls) */
+main:focus {
+  outline: none;
+}
+
 /* ---------- Site header ---------- */
 
 .site-header {
@@ -408,6 +414,43 @@ code {
   border: 1px solid var(--color-border);
   border-radius: var(--radius);
   padding: 0.6em 0.8em;
+}
+
+/* Markdown editors and long descriptions */
+textarea.form__input {
+  min-height: 8rem;
+  resize: vertical;
+}
+
+/* Action buttons that sit inside a line of text or a list item */
+.form--inline {
+  display: inline;
+}
+
+/* ---------- Data tables (e.g. the course roster) ---------- */
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+}
+
+.table th,
+.table td {
+  text-align: left;
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.table th {
+  font-family: var(--font-display);
+  font-size: var(--font-size-sm);
+}
+
+.table tr:last-child td {
+  border-bottom: 0;
 }
 
 .form__input:focus-visible {

--- a/docs/design/mockups/error.html
+++ b/docs/design/mockups/error.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Dashboard — learn-dev</title>
+  <title>Page not found — learn-dev</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:wght@400;700&family=Sora:wght@600;700&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
@@ -18,7 +18,7 @@
       <a class="site-header__brand" href="home.html">learn<span class="site-header__brand-mark">-dev</span></a>
       <nav class="site-header__nav" aria-label="Main">
         <ul class="nav__list">
-          <li><a class="nav__link" href="dashboard.html" aria-current="page">Dashboard</a></li>
+          <li><a class="nav__link" href="dashboard.html">Dashboard</a></li>
           <li><a class="nav__link" href="courses.html">Courses</a></li>
           <li>
             <!-- Logout is a POST in the real app (CSRF); styled as a ghost button -->
@@ -31,27 +31,12 @@
     </div>
   </header>
 
-  <main class="site-main" id="main" tabindex="-1">
-    <h1 class="page-title">Welcome back, <strong>carol</strong> 👋</h1>
-
-    <section aria-labelledby="courses-title">
-      <h2 id="courses-title">Your courses</h2>
-
-      <ul class="course-list">
-        <li class="course-card">
-          <h3 class="course-card__title"><a href="course.html">Python for curious minds</a></h3>
-          <p class="course-card__meta">Enrolled &middot; since 13 July 2026</p>
-        </li>
-        <li class="course-card">
-          <h3 class="course-card__title"><a href="course.html">Git from the ground up</a></h3>
-          <p class="course-card__meta">In progress &middot; since 2 July 2026</p>
-        </li>
-        <li class="course-card">
-          <h3 class="course-card__title"><a href="course.html">Accessible HTML and CSS</a></h3>
-          <p class="course-card__meta">Completed &middot; since 15 June 2026</p>
-        </li>
-      </ul>
-    </section>
+  <main class="site-main site-main--narrow" id="main" tabindex="-1">
+    <h1>Page not found</h1>
+    <p>The page you are looking for does not exist or has moved.</p>
+    <p>
+      <a class="button button--primary" href="home.html">Back to the home page</a>
+    </p>
   </main>
 
   <footer class="site-footer">

--- a/docs/design/mockups/index.html
+++ b/docs/design/mockups/index.html
@@ -44,7 +44,39 @@
       </li>
       <li class="feature-card">
         <h2 class="feature-card__title"><a href="dashboard.html">Dashboard</a></h2>
-        <p class="feature-card__text">Stats and course progress (authenticated).</p>
+        <p class="feature-card__text">The student's courses (authenticated).</p>
+      </li>
+      <li class="feature-card">
+        <h2 class="feature-card__title"><a href="courses.html">Courses</a></h2>
+        <p class="feature-card__text">Published course catalogue with enrollment marker.</p>
+      </li>
+      <li class="feature-card">
+        <h2 class="feature-card__title"><a href="course.html">Course</a></h2>
+        <p class="feature-card__text">Detail page, enroll/quit action, lesson list.</p>
+      </li>
+      <li class="feature-card">
+        <h2 class="feature-card__title"><a href="lesson.html">Lesson</a></h2>
+        <p class="feature-card__text">Rendered Markdown (headings demoted, ADR-0014).</p>
+      </li>
+      <li class="feature-card">
+        <h2 class="feature-card__title"><a href="instructor-courses.html">Instructor: my courses</a></h2>
+        <p class="feature-card__text">Authoring entry point, all statuses.</p>
+      </li>
+      <li class="feature-card">
+        <h2 class="feature-card__title"><a href="instructor-course-editor.html">Instructor: course editor</a></h2>
+        <p class="feature-card__text">Form, lifecycle actions, lesson management.</p>
+      </li>
+      <li class="feature-card">
+        <h2 class="feature-card__title"><a href="instructor-lesson-editor.html">Instructor: lesson editor</a></h2>
+        <p class="feature-card__text">Title and Markdown content form.</p>
+      </li>
+      <li class="feature-card">
+        <h2 class="feature-card__title"><a href="instructor-students.html">Instructor: students</a></h2>
+        <p class="feature-card__text">Roster table with the remove action.</p>
+      </li>
+      <li class="feature-card">
+        <h2 class="feature-card__title"><a href="error.html">Error page</a></h2>
+        <p class="feature-card__text">Styled 404; 403 and 500 share the shape.</p>
       </li>
     </ul>
 

--- a/docs/design/mockups/instructor-course-editor.html
+++ b/docs/design/mockups/instructor-course-editor.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Course editor — learn-dev</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:wght@400;700&family=Sora:wght@600;700&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/theme-catppuccin.css">
+  <link rel="stylesheet" href="css/base.css">
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to main content</a>
+
+  <header class="site-header">
+    <div class="site-header__inner">
+      <a class="site-header__brand" href="home.html">learn<span class="site-header__brand-mark">-dev</span></a>
+      <nav class="site-header__nav" aria-label="Main">
+        <ul class="nav__list">
+          <li><a class="nav__link" href="dashboard.html">Dashboard</a></li>
+          <li><a class="nav__link" href="courses.html">Courses</a></li>
+          <li><a class="nav__link" href="instructor-courses.html" aria-current="page">Instructor</a></li>
+          <li>
+            <!-- Logout is a POST in the real app (CSRF); styled as a ghost button -->
+            <form action="#" method="post">
+              <button class="button button--ghost" type="submit">Log out</button>
+            </form>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main class="site-main" id="main" tabindex="-1">
+    <p class="alert alert--success" role="status">
+      Lesson published.
+    </p>
+
+    <div class="form-card">
+      <h1 class="form-card__title">Edit the course</h1>
+
+      <p class="course-card__meta">Status: Draft</p>
+
+      <form action="#" method="post">
+        <div class="form__group">
+          <label class="form__label" for="title">Title</label>
+          <span class="form__hint" id="title-hint">Up to 255 characters.</span>
+          <input class="form__input" type="text" id="title" name="title"
+                 value="Python for curious minds" required aria-describedby="title-hint">
+        </div>
+
+        <div class="form__group">
+          <label class="form__label" for="description">Description</label>
+          <span class="form__hint" id="description-hint">
+            Optional. Shown to students in the catalogue.
+          </span>
+          <textarea class="form__input" id="description" name="description" rows="4"
+                    aria-describedby="description-hint">Loops, lists, and a taste of the standard library.</textarea>
+        </div>
+
+        <button class="button button--primary" type="submit">Save the course</button>
+      </form>
+    </div>
+
+    <section aria-labelledby="lifecycle-title">
+      <h2 id="lifecycle-title" class="visually-hidden">Publication actions</h2>
+      <form action="#" method="post">
+        <button class="button button--primary" type="submit">Publish the course</button>
+      </form>
+      <form action="#" method="post">
+        <button class="button button--ghost" type="submit">Archive the course</button>
+      </form>
+    </section>
+
+    <p><a href="instructor-students.html">View the students of this course</a></p>
+
+    <section aria-labelledby="lessons-title">
+      <h2 id="lessons-title">Lessons</h2>
+
+      <p><a class="button button--ghost" href="instructor-lesson-editor.html">Add a lesson</a></p>
+
+      <ol>
+        <li>
+          <a href="instructor-lesson-editor.html">Lists in five minutes</a>
+          <span class="course-card__meta">(Published)</span>
+          <form class="form--inline" action="#" method="post">
+            <button class="button button--ghost" type="submit">Move down
+              <span class="visually-hidden">: Lists in five minutes</span></button>
+          </form>
+          <form class="form--inline" action="#" method="post">
+            <button class="button button--ghost" type="submit">Archive
+              <span class="visually-hidden">: Lists in five minutes</span></button>
+          </form>
+        </li>
+        <li>
+          <a href="instructor-lesson-editor.html">Loops without tears</a>
+          <span class="course-card__meta">(Draft)</span>
+          <form class="form--inline" action="#" method="post">
+            <button class="button button--ghost" type="submit">Move up
+              <span class="visually-hidden">: Loops without tears</span></button>
+          </form>
+          <form class="form--inline" action="#" method="post">
+            <button class="button button--primary" type="submit">Publish
+              <span class="visually-hidden">: Loops without tears</span></button>
+          </form>
+          <form class="form--inline" action="#" method="post">
+            <button class="button button--ghost" type="submit">Archive
+              <span class="visually-hidden">: Loops without tears</span></button>
+          </form>
+        </li>
+      </ol>
+    </section>
+
+    <p><a href="instructor-courses.html">Back to my courses</a></p>
+  </main>
+
+  <footer class="site-footer">
+    <div class="site-footer__inner">
+      <p>learn-dev, an interactive programming learning platform.</p>
+      <p><a href="https://github.com/ebouchut/learn-dev">Source on GitHub</a></p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/docs/design/mockups/instructor-courses.html
+++ b/docs/design/mockups/instructor-courses.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Dashboard — learn-dev</title>
+  <title>My courses — learn-dev</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:wght@400;700&family=Sora:wght@600;700&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
@@ -18,8 +18,9 @@
       <a class="site-header__brand" href="home.html">learn<span class="site-header__brand-mark">-dev</span></a>
       <nav class="site-header__nav" aria-label="Main">
         <ul class="nav__list">
-          <li><a class="nav__link" href="dashboard.html" aria-current="page">Dashboard</a></li>
+          <li><a class="nav__link" href="dashboard.html">Dashboard</a></li>
           <li><a class="nav__link" href="courses.html">Courses</a></li>
+          <li><a class="nav__link" href="instructor-courses.html" aria-current="page">Instructor</a></li>
           <li>
             <!-- Logout is a POST in the real app (CSRF); styled as a ghost button -->
             <form action="#" method="post">
@@ -32,26 +33,22 @@
   </header>
 
   <main class="site-main" id="main" tabindex="-1">
-    <h1 class="page-title">Welcome back, <strong>carol</strong> 👋</h1>
+    <h1 class="page-title">My courses</h1>
 
-    <section aria-labelledby="courses-title">
-      <h2 id="courses-title">Your courses</h2>
+    <p>
+      <a class="button button--primary" href="instructor-course-editor.html">Create a course</a>
+    </p>
 
-      <ul class="course-list">
-        <li class="course-card">
-          <h3 class="course-card__title"><a href="course.html">Python for curious minds</a></h3>
-          <p class="course-card__meta">Enrolled &middot; since 13 July 2026</p>
-        </li>
-        <li class="course-card">
-          <h3 class="course-card__title"><a href="course.html">Git from the ground up</a></h3>
-          <p class="course-card__meta">In progress &middot; since 2 July 2026</p>
-        </li>
-        <li class="course-card">
-          <h3 class="course-card__title"><a href="course.html">Accessible HTML and CSS</a></h3>
-          <p class="course-card__meta">Completed &middot; since 15 June 2026</p>
-        </li>
-      </ul>
-    </section>
+    <ul class="course-list">
+      <li class="course-card">
+        <h2 class="course-card__title"><a href="instructor-course-editor.html">Python for curious minds</a></h2>
+        <p class="course-card__meta">Status: Published &middot; first published on 13 July 2026</p>
+      </li>
+      <li class="course-card">
+        <h2 class="course-card__title"><a href="instructor-course-editor.html">Rust for the brave</a></h2>
+        <p class="course-card__meta">Status: Draft</p>
+      </li>
+    </ul>
   </main>
 
   <footer class="site-footer">

--- a/docs/design/mockups/instructor-lesson-editor.html
+++ b/docs/design/mockups/instructor-lesson-editor.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Dashboard — learn-dev</title>
+  <title>Lesson editor — learn-dev</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:wght@400;700&family=Sora:wght@600;700&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
@@ -18,8 +18,9 @@
       <a class="site-header__brand" href="home.html">learn<span class="site-header__brand-mark">-dev</span></a>
       <nav class="site-header__nav" aria-label="Main">
         <ul class="nav__list">
-          <li><a class="nav__link" href="dashboard.html" aria-current="page">Dashboard</a></li>
+          <li><a class="nav__link" href="dashboard.html">Dashboard</a></li>
           <li><a class="nav__link" href="courses.html">Courses</a></li>
+          <li><a class="nav__link" href="instructor-courses.html" aria-current="page">Instructor</a></li>
           <li>
             <!-- Logout is a POST in the real app (CSRF); styled as a ghost button -->
             <form action="#" method="post">
@@ -32,26 +33,28 @@
   </header>
 
   <main class="site-main" id="main" tabindex="-1">
-    <h1 class="page-title">Welcome back, <strong>carol</strong> 👋</h1>
+    <p class="course-card__meta"><a href="instructor-course-editor.html">Python for curious minds</a></p>
+    <h1 class="page-title">Add a lesson</h1>
 
-    <section aria-labelledby="courses-title">
-      <h2 id="courses-title">Your courses</h2>
+    <form action="#" method="post">
+      <div class="form__group">
+        <label class="form__label" for="title">Title</label>
+        <span class="form__hint" id="title-hint">Up to 255 characters.</span>
+        <input class="form__input" type="text" id="title" name="title" required
+               aria-describedby="title-hint">
+      </div>
 
-      <ul class="course-list">
-        <li class="course-card">
-          <h3 class="course-card__title"><a href="course.html">Python for curious minds</a></h3>
-          <p class="course-card__meta">Enrolled &middot; since 13 July 2026</p>
-        </li>
-        <li class="course-card">
-          <h3 class="course-card__title"><a href="course.html">Git from the ground up</a></h3>
-          <p class="course-card__meta">In progress &middot; since 2 July 2026</p>
-        </li>
-        <li class="course-card">
-          <h3 class="course-card__title"><a href="course.html">Accessible HTML and CSS</a></h3>
-          <p class="course-card__meta">Completed &middot; since 15 June 2026</p>
-        </li>
-      </ul>
-    </section>
+      <div class="form__group">
+        <label class="form__label" for="contentMarkdown">Content (Markdown)</label>
+        <span class="form__hint" id="content-hint">
+          Markdown is rendered and sanitized before students see it.
+        </span>
+        <textarea class="form__input" id="contentMarkdown" name="contentMarkdown" rows="12"
+                  aria-describedby="content-hint"></textarea>
+      </div>
+
+      <button class="button button--primary" type="submit">Add the lesson</button>
+    </form>
   </main>
 
   <footer class="site-footer">

--- a/docs/design/mockups/instructor-students.html
+++ b/docs/design/mockups/instructor-students.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Dashboard — learn-dev</title>
+  <title>Students — learn-dev</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:wght@400;700&family=Sora:wght@600;700&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
@@ -18,8 +18,9 @@
       <a class="site-header__brand" href="home.html">learn<span class="site-header__brand-mark">-dev</span></a>
       <nav class="site-header__nav" aria-label="Main">
         <ul class="nav__list">
-          <li><a class="nav__link" href="dashboard.html" aria-current="page">Dashboard</a></li>
+          <li><a class="nav__link" href="dashboard.html">Dashboard</a></li>
           <li><a class="nav__link" href="courses.html">Courses</a></li>
+          <li><a class="nav__link" href="instructor-courses.html" aria-current="page">Instructor</a></li>
           <li>
             <!-- Logout is a POST in the real app (CSRF); styled as a ghost button -->
             <form action="#" method="post">
@@ -32,26 +33,44 @@
   </header>
 
   <main class="site-main" id="main" tabindex="-1">
-    <h1 class="page-title">Welcome back, <strong>carol</strong> 👋</h1>
+    <p class="course-card__meta"><a href="instructor-course-editor.html">Python for curious minds</a></p>
+    <h1 class="page-title">Students</h1>
 
-    <section aria-labelledby="courses-title">
-      <h2 id="courses-title">Your courses</h2>
+    <table class="table">
+      <caption class="visually-hidden">Students enrolled in Python for curious minds</caption>
+      <thead>
+        <tr>
+          <th scope="col">Student</th>
+          <th scope="col">Status</th>
+          <th scope="col">Enrolled on</th>
+          <th scope="col">Left on</th>
+          <th scope="col">Action</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>carol</td>
+          <td>Enrolled</td>
+          <td>13 July 2026</td>
+          <td>-</td>
+          <td>
+            <form action="#" method="post">
+              <button class="button button--ghost" type="submit">Remove
+                <span class="visually-hidden">: carol</span></button>
+            </form>
+          </td>
+        </tr>
+        <tr>
+          <td>sam</td>
+          <td>Dropped</td>
+          <td>2 July 2026</td>
+          <td>9 July 2026</td>
+          <td></td>
+        </tr>
+      </tbody>
+    </table>
 
-      <ul class="course-list">
-        <li class="course-card">
-          <h3 class="course-card__title"><a href="course.html">Python for curious minds</a></h3>
-          <p class="course-card__meta">Enrolled &middot; since 13 July 2026</p>
-        </li>
-        <li class="course-card">
-          <h3 class="course-card__title"><a href="course.html">Git from the ground up</a></h3>
-          <p class="course-card__meta">In progress &middot; since 2 July 2026</p>
-        </li>
-        <li class="course-card">
-          <h3 class="course-card__title"><a href="course.html">Accessible HTML and CSS</a></h3>
-          <p class="course-card__meta">Completed &middot; since 15 June 2026</p>
-        </li>
-      </ul>
-    </section>
+    <p><a href="instructor-courses.html">Back to my courses</a></p>
   </main>
 
   <footer class="site-footer">

--- a/docs/design/mockups/lesson.html
+++ b/docs/design/mockups/lesson.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Dashboard — learn-dev</title>
+  <title>Lesson — learn-dev</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:wght@400;700&family=Sora:wght@600;700&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
@@ -18,8 +18,8 @@
       <a class="site-header__brand" href="home.html">learn<span class="site-header__brand-mark">-dev</span></a>
       <nav class="site-header__nav" aria-label="Main">
         <ul class="nav__list">
-          <li><a class="nav__link" href="dashboard.html" aria-current="page">Dashboard</a></li>
-          <li><a class="nav__link" href="courses.html">Courses</a></li>
+          <li><a class="nav__link" href="dashboard.html">Dashboard</a></li>
+          <li><a class="nav__link" href="courses.html" aria-current="page">Courses</a></li>
           <li>
             <!-- Logout is a POST in the real app (CSRF); styled as a ghost button -->
             <form action="#" method="post">
@@ -32,26 +32,24 @@
   </header>
 
   <main class="site-main" id="main" tabindex="-1">
-    <h1 class="page-title">Welcome back, <strong>carol</strong> 👋</h1>
+    <p class="course-card__meta"><a href="course.html">Python for curious minds</a></p>
+    <h1 class="page-title">Lists in five minutes</h1>
 
-    <section aria-labelledby="courses-title">
-      <h2 id="courses-title">Your courses</h2>
-
-      <ul class="course-list">
-        <li class="course-card">
-          <h3 class="course-card__title"><a href="course.html">Python for curious minds</a></h3>
-          <p class="course-card__meta">Enrolled &middot; since 13 July 2026</p>
-        </li>
-        <li class="course-card">
-          <h3 class="course-card__title"><a href="course.html">Git from the ground up</a></h3>
-          <p class="course-card__meta">In progress &middot; since 2 July 2026</p>
-        </li>
-        <li class="course-card">
-          <h3 class="course-card__title"><a href="course.html">Accessible HTML and CSS</a></h3>
-          <p class="course-card__meta">Completed &middot; since 15 June 2026</p>
-        </li>
+    <article>
+      <!-- Sanitized HTML from MarkdownRenderer; authored "# ..." arrives as h2 (ADR-0014) -->
+      <h2>Why lists matter</h2>
+      <p>Lists hold <em>ordered</em> values. Try <code>mylist.append(42)</code>.</p>
+      <ul>
+        <li>they keep insertion order</li>
+        <li>they grow as needed</li>
       </ul>
-    </section>
+      <pre><code class="language-python">numbers = [1, 2, 3]
+numbers.append(4)</code></pre>
+    </article>
+
+    <nav aria-label="Lesson">
+      <a class="button button--primary" href="lesson.html">Next: Loops without tears</a>
+    </nav>
   </main>
 
   <footer class="site-footer">


### PR DESCRIPTION
This PR updates and synchronizes the **HTML prototype** to **reflect the current state of the UI** (User Interface).

Now that the UI has reached a stable milestone (with student catalog, instructor course authoring, and error pages), this PR updates the browsable prototype in `docs/design/mockups` to align with the app:

- **`css/base.css`** is realigned with the app stylesheet (including the explicit skip-link focus, *Markdown* textarea, inline action forms, and roster table styles).
- **`dashboard.html`** now mirrors the dashboard where aspirational stats row and progress bars have been replaced with enrollment cards that display status and date information.
- Add **new snapshots**: 
    - Courses, 
    - Course, 
    - Lesson (Markdown output with demoted headings, See [ADR-0014](https://github.com/ebouchut/learn-dev/blob/dev/docs/adr/0014-demote-markdown-headings-in-lesson-rendering.md)), 
    - Instructor pages, 
    - Styled error page,
    - `index.html` lists all the snapshots.
- **`course-pages-explained.md`** documents these changes (one noticing point per page).