### PR TITLE
feat(auth): Verify email addresses with a single-use emailed link

### DIFF
--- a/src/main/java/com/ericbouchut/learndev/auth/AuthController.java
+++ b/src/main/java/com/ericbouchut/learndev/auth/AuthController.java
@@ -3,6 +3,8 @@ package com.ericbouchut.learndev.auth;
 import com.ericbouchut.learndev.auth.dto.RegisterForm;
 import com.ericbouchut.learndev.auth.exception.DuplicateEmailException;
 import com.ericbouchut.learndev.auth.exception.DuplicateUsernameException;
+import com.ericbouchut.learndev.user.entity.User;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -23,9 +25,12 @@ import org.springframework.web.bind.annotation.PostMapping;
 public class AuthController {
 
     private final RegistrationService registration;
+    private final EmailVerificationService verification;
 
-    public AuthController(RegistrationService registration) {
+    public AuthController(RegistrationService registration,
+                          EmailVerificationService verification) {
         this.registration = registration;
+        this.verification = verification;
     }
 
     /**
@@ -76,13 +81,15 @@ public class AuthController {
             @ModelAttribute("form")
             RegisterForm form,
 
-            BindingResult binding
+            BindingResult binding,
+            HttpServletRequest request
     ) {
         if (binding.hasErrors()) {
             return "register";
         }
+        User user;
         try {
-            registration.register(form);
+            user = registration.register(form);
         } catch (DuplicateUsernameException e) {
             binding.rejectValue("username", "duplicate", "Username already taken");
             return "register";
@@ -90,6 +97,8 @@ public class AuthController {
             binding.rejectValue("email", "duplicate", "Email already registered");
             return "register";
         }
+        verification.sendVerification(user, request.getRemoteAddr(),
+                EmailVerificationController.verifyUrlBase(request));
         return "redirect:/auth/login?registered";
     }
 }

--- a/src/main/java/com/ericbouchut/learndev/auth/EmailVerificationController.java
+++ b/src/main/java/com/ericbouchut/learndev/auth/EmailVerificationController.java
@@ -1,0 +1,73 @@
+package com.ericbouchut.learndev.auth;
+
+import com.ericbouchut.learndev.user.entity.User;
+import com.ericbouchut.learndev.user.repository.UserRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.security.Principal;
+
+/**
+ * <b>Web</b> endpoints of the email verification flow: the emailed link
+ * lands on {@code GET /auth/verify} (public, like the whole {@code /auth}
+ * prefix), and a logged-in user can ask for a fresh link from the dashboard
+ * banner. The outcome is carried by query flags on the redirect targets,
+ * following the house PRG idiom.
+ */
+@Controller
+public class EmailVerificationController {
+
+    private final EmailVerificationService verification;
+    private final UserRepository users;
+
+    public EmailVerificationController(
+            EmailVerificationService verification,
+            UserRepository users
+    ) {
+        this.verification = verification;
+        this.users = users;
+    }
+
+    /**
+     * Consume the emailed verification link.
+     *
+     * @param token   the raw token from the link
+     * @param request provides the client IP for the audit trail
+     * @return a redirect to the login page with a verified or invalid flag
+     */
+    @GetMapping("/auth/verify")
+    public String verify(@RequestParam String token, HttpServletRequest request) {
+        boolean verified = verification.verify(token, request.getRemoteAddr());
+        return "redirect:/auth/login?" + (verified ? "verified" : "verify-invalid");
+    }
+
+    /**
+     * Send a fresh verification link to the logged-in user (dashboard
+     * banner action).
+     *
+     * @param principal the logged-in user, or null when the session expired
+     * @param request   provides the client IP and the absolute verify URL
+     * @return a redirect to the dashboard with a confirmation flag
+     */
+    @PostMapping("/auth/verify/resend")
+    public String resend(Principal principal, HttpServletRequest request) {
+        if (principal == null) {
+            return "redirect:/auth/login";
+        }
+        User user = users.findByUsername(principal.getName())
+                .orElseThrow(() -> new IllegalStateException(
+                        "Authenticated user not found: " + principal.getName()));
+        verification.sendVerification(user, request.getRemoteAddr(), verifyUrlBase(request));
+        return "redirect:/dashboard?verification-sent";
+    }
+
+    static String verifyUrlBase(HttpServletRequest request) {
+        return ServletUriComponentsBuilder.fromRequestUri(request)
+                .replacePath("/auth/verify")
+                .toUriString();
+    }
+}

--- a/src/main/java/com/ericbouchut/learndev/auth/EmailVerificationMailer.java
+++ b/src/main/java/com/ericbouchut/learndev/auth/EmailVerificationMailer.java
@@ -1,0 +1,54 @@
+package com.ericbouchut.learndev.auth;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+/**
+ * Sends the email-verification message. In development the message is
+ * caught by Mailpit (web UI: http://localhost:8025); nothing leaves the
+ * machine.
+ */
+@Component
+public class EmailVerificationMailer {
+
+    private final JavaMailSender mailSender;
+    private final String from;
+    private final Duration tokenTtl;
+
+    public EmailVerificationMailer(JavaMailSender mailSender,
+                                   @Value("${learndev.mail.from}") String from,
+                                   @Value("${learndev.email-verification.token-ttl}") Duration tokenTtl) {
+        this.mailSender = mailSender;
+        this.from = from;
+        this.tokenTtl = tokenTtl;
+    }
+
+    /**
+     * @param to         recipient email address
+     * @param verifyLink absolute URL containing the RAW token; the raw token
+     *                   exists only in this email and in the URL bar, never
+     *                   in the database or the logs
+     */
+    public void sendVerificationEmail(String to, String verifyLink) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setFrom(from);
+        message.setTo(to);
+        message.setSubject("Verify your learn-dev email address");
+        message.setText("""
+                Welcome to learn-dev!
+
+                To confirm that this address is yours, open this link \
+                (valid for %d hours, single use):
+
+                %s
+
+                If you did not create a learn-dev account, you can safely \
+                ignore this email.
+                """.formatted(tokenTtl.toHours(), verifyLink));
+        mailSender.send(message);
+    }
+}

--- a/src/main/java/com/ericbouchut/learndev/auth/EmailVerificationService.java
+++ b/src/main/java/com/ericbouchut/learndev/auth/EmailVerificationService.java
@@ -1,0 +1,122 @@
+package com.ericbouchut.learndev.auth;
+
+import com.ericbouchut.learndev.audit.AuditService;
+import com.ericbouchut.learndev.auth.entity.EmailToken;
+import com.ericbouchut.learndev.auth.repository.EmailTokenRepository;
+import com.ericbouchut.learndev.user.entity.User;
+import com.ericbouchut.learndev.user.repository.UserRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.MailException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.Base64;
+
+/**
+ * Email verification: proves the registered address belongs to the user.
+ * Same token discipline as the password reset: a 32-byte random secret sent
+ * by email, stored only as its SHA-256 hash, single active token per user,
+ * single use, with a TTL (configurable under
+ * {@code learndev.email-verification.*}). Verification is informational in
+ * v1 (a dashboard banner until done); it does not gate any feature yet.
+ */
+@Service
+public class EmailVerificationService {
+
+    private static final Logger log = LoggerFactory.getLogger(EmailVerificationService.class);
+
+    private final EmailTokenRepository tokens;
+    private final UserRepository users;
+    private final EmailVerificationMailer mailer;
+    private final AuditService audit;
+    private final Duration tokenTtl;
+
+    private final SecureRandom random = new SecureRandom();
+
+    public EmailVerificationService(
+            EmailTokenRepository tokens,
+            UserRepository users,
+            EmailVerificationMailer mailer,
+            AuditService audit,
+            @Value("${learndev.email-verification.token-ttl}") Duration tokenTtl
+    ) {
+        this.tokens = tokens;
+        this.users = users;
+        this.mailer = mailer;
+        this.audit = audit;
+        this.tokenTtl = tokenTtl;
+    }
+
+    /**
+     * Issue a fresh token for the user (invalidating any open one) and
+     * email the verification link. A mail failure is logged and audited but
+     * not surfaced: registration must not fail because SMTP hiccuped.
+     *
+     * @param user          the account to verify
+     * @param ipAddress     requester IP for the audit trail
+     * @param verifyUrlBase absolute URL of the verify endpoint, without the token
+     */
+    @Transactional
+    public void sendVerification(User user, String ipAddress, String verifyUrlBase) {
+        if (user.isVerified()) {
+            return;
+        }
+        OffsetDateTime now = OffsetDateTime.now();
+        tokens.findByUserAndUsedAtIsNull(user).forEach(open -> {
+            open.setUsedAt(now);
+            tokens.save(open);
+        });
+
+        byte[] secret = new byte[32];
+        random.nextBytes(secret);
+        String rawToken = Base64.getUrlEncoder().withoutPadding().encodeToString(secret);
+
+        EmailToken token = new EmailToken();
+        token.setUser(user);
+        token.setToken(PasswordResetService.sha256(rawToken));
+        token.setExpiresAt(now.plus(tokenTtl));
+        tokens.save(token);
+
+        try {
+            mailer.sendVerificationEmail(user.getEmail(), verifyUrlBase + "?token=" + rawToken);
+            audit.record("EMAIL_VERIFICATION_SENT", user, ipAddress, true,
+                    "Verification email sent");
+        } catch (MailException e) {
+            log.error("Could not send the verification email", e);
+            audit.record("EMAIL_VERIFICATION_SENT", user, ipAddress, false,
+                    "Verification email could not be sent");
+        }
+    }
+
+    /**
+     * Consume a verification token: marks the user verified and burns the
+     * token. Unknown, expired, or already-used tokens simply return false
+     * (the caller shows a neutral invalid-link message).
+     *
+     * @param rawToken  the raw token from the emailed link
+     * @param ipAddress requester IP for the audit trail
+     * @return true when the email is now verified
+     */
+    @Transactional
+    public boolean verify(String rawToken, String ipAddress) {
+        OffsetDateTime now = OffsetDateTime.now();
+        return tokens.findByToken(PasswordResetService.sha256(rawToken))
+                .filter(token -> token.isUsable(now))
+                .map(token -> {
+                    token.setUsedAt(now);
+                    tokens.save(token);
+                    User user = token.getUser();
+                    user.setVerified(true);
+                    users.save(user);
+                    audit.record("EMAIL_VERIFIED", user, ipAddress, true,
+                            "Email address verified");
+                    return true;
+                })
+                .orElse(false);
+    }
+}

--- a/src/main/java/com/ericbouchut/learndev/auth/entity/EmailToken.java
+++ b/src/main/java/com/ericbouchut/learndev/auth/entity/EmailToken.java
@@ -1,0 +1,48 @@
+package com.ericbouchut.learndev.auth.entity;
+
+import com.ericbouchut.learndev.user.entity.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.OffsetDateTime;
+
+/**
+ * A single-use, expiring email-verification token (maps the
+ * {@code email_tokens} table). Like the password-reset token, the
+ * {@code token} column stores the SHA-256 <b>hash</b> of the raw secret sent
+ * by email, never the secret itself.
+ */
+@Entity
+@Table(name = "email_tokens")
+@Getter
+@Setter
+@NoArgsConstructor
+public class EmailToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "token_id")
+    private Long tokenId;
+
+    /** SHA-256 hash (hex) of the raw token; unique so lookups are by hash. */
+    @Column(name = "token", nullable = false, unique = true)
+    private String token;
+
+    @Column(name = "expires_at", nullable = false)
+    private OffsetDateTime expiresAt;
+
+    /** Set when the token is consumed or invalidated; single-use guard. */
+    @Column(name = "used_at")
+    private OffsetDateTime usedAt;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    /** True when the token can still be consumed (not used, not expired). */
+    public boolean isUsable(OffsetDateTime now) {
+        return usedAt == null && expiresAt.isAfter(now);
+    }
+}

--- a/src/main/java/com/ericbouchut/learndev/auth/repository/EmailTokenRepository.java
+++ b/src/main/java/com/ericbouchut/learndev/auth/repository/EmailTokenRepository.java
@@ -1,0 +1,17 @@
+package com.ericbouchut.learndev.auth.repository;
+
+import com.ericbouchut.learndev.auth.entity.EmailToken;
+import com.ericbouchut.learndev.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface EmailTokenRepository extends JpaRepository<EmailToken, Long> {
+
+    /** Lookup by SHA-256 hash (the raw token is never stored). */
+    Optional<EmailToken> findByToken(String token);
+
+    /** The user's tokens that were never consumed (to invalidate on resend). */
+    List<EmailToken> findByUserAndUsedAtIsNull(User user);
+}

--- a/src/main/java/com/ericbouchut/learndev/course/DashboardController.java
+++ b/src/main/java/com/ericbouchut/learndev/course/DashboardController.java
@@ -43,6 +43,7 @@ public class DashboardController {
                 enrollmentService.myEnrollments(user).stream()
                         .filter(e -> e.getStatus() != EnrollmentStatus.DROPPED)
                         .toList());
+        model.addAttribute("emailVerified", user.isVerified());
         return "dashboard";
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -65,6 +65,12 @@ learndev:
   mail:
     # Sender address for transactional emails (password reset)
     from: noreply@learn-dev.local
+  lockout:
+    # Consecutive failed logins before the account is locked
+    max-attempts: 5
+  email-verification:
+    # How long a verification link stays valid
+    token-ttl: 24h
   password-reset:
     # How long a reset token stays valid
     token-ttl: 30m

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -6,6 +6,16 @@
   <th:block th:replace="~{fragments/layout :: header('dashboard')}"></th:block>
 
   <main class="site-main" id="main" tabindex="-1">
+    <p class="alert alert--success" role="status" th:if="${param['verification-sent']}">
+      Verification email sent. Check your inbox.
+    </p>
+    <div class="alert alert--info" role="status" th:unless="${emailVerified}">
+      Your email address is not verified yet. Open the link we sent you, or
+      <form class="form--inline" th:action="@{/auth/verify/resend}" method="post">
+        <button class="button button--ghost" type="submit">resend the email</button>
+      </form>
+    </div>
+
     <h1 class="page-title">
       Welcome back, <strong sec:authentication="name">user</strong> 👋
     </h1>

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -6,7 +6,15 @@
 
   <main class="site-main site-main--narrow" id="main" tabindex="-1">
     <p class="alert alert--success" role="status" th:if="${param.registered}">
-      Account created, please log in.
+      Account created, please log in. We sent you an email to verify your
+      address.
+    </p>
+    <p class="alert alert--success" role="status" th:if="${param.verified}">
+      Your email address is verified. Thank you!
+    </p>
+    <p class="alert alert--error" role="alert" th:if="${param['verify-invalid']}">
+      This verification link is invalid, expired, or has already been used.
+      Log in and use the resend button on your dashboard.
     </p>
     <p class="alert alert--success" role="status" th:if="${param.reset}">
       Your password has been changed, please log in.

--- a/src/test/java/com/ericbouchut/learndev/auth/EmailVerificationFlowTest.java
+++ b/src/test/java/com/ericbouchut/learndev/auth/EmailVerificationFlowTest.java
@@ -1,0 +1,151 @@
+package com.ericbouchut.learndev.auth;
+
+import com.ericbouchut.learndev.support.AbstractPostgresIT;
+import com.ericbouchut.learndev.user.repository.UserRepository;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.GenericContainer;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * End-to-end email verification loop: register, capture the real email
+ * through Mailpit's REST API, follow the link, and prove the account is
+ * verified and the token single-use; then the resend path from the
+ * dashboard banner issues a fresh working link.
+ *
+ * <p>Runs against the shared Testcontainers PostgreSQL plus a Mailpit
+ * container as the SMTP target (the same image used by docker compose).
+ *
+ * <p>Named with the {@code Test} suffix (not {@code IT}) so Surefire runs it
+ * as part of {@code mvn test}; this project does not use the Failsafe plugin.
+ */
+@SpringBootTest(properties = {
+        // This feature does not use MongoDB; keep the test context Postgres-only.
+        "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration,"
+                + "org.springframework.boot.autoconfigure.data.mongo.MongoDataAutoConfiguration"
+})
+@AutoConfigureMockMvc
+class EmailVerificationFlowTest extends AbstractPostgresIT {
+
+    /** Shared like the Postgres container: started once for the class. */
+    static final GenericContainer<?> MAILPIT =
+            new GenericContainer<>("axllent/mailpit")
+                    .withExposedPorts(1025, 8025);
+
+    static {
+        MAILPIT.start();
+    }
+
+    @DynamicPropertySource
+    static void mailProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.mail.host", MAILPIT::getHost);
+        registry.add("spring.mail.port", () -> MAILPIT.getMappedPort(1025));
+    }
+
+    @Autowired
+    MockMvc mvc;
+
+    @Autowired
+    UserRepository userRepository;
+
+    final HttpClient http = HttpClient.newHttpClient();
+    final ObjectMapper json = new ObjectMapper();
+
+    @Test
+    void registration_sends_a_single_use_verification_link() throws Exception {
+        // Registering triggers the verification email.
+        mvc.perform(post("/auth/register").with(csrf())
+                        .param("username", "verifyme")
+                        .param("email", "verifyme@example.com")
+                        .param("password", "secret12"))
+                .andExpect(status().is3xxRedirection());
+        assertThat(userRepository.findByUsername("verifyme").orElseThrow().isVerified())
+                .isFalse();
+
+        // The email went through real SMTP into Mailpit; read it back.
+        String rawToken = tokenFromLatestEmail(1);
+
+        // Following the link verifies the account.
+        mvc.perform(get("/auth/verify").param("token", rawToken))
+                .andExpect(redirectedUrl("/auth/login?verified"));
+        assertThat(userRepository.findByUsername("verifyme").orElseThrow().isVerified())
+                .isTrue();
+
+        // Single use: the same token is now rejected.
+        mvc.perform(get("/auth/verify").param("token", rawToken))
+                .andExpect(redirectedUrl("/auth/login?verify-invalid"));
+    }
+
+    @Test
+    void the_dashboard_resend_issues_a_fresh_working_link() throws Exception {
+        mvc.perform(post("/auth/register").with(csrf())
+                        .param("username", "resender")
+                        .param("email", "resender@example.com")
+                        .param("password", "secret12"))
+                .andExpect(status().is3xxRedirection());
+        String firstToken = tokenFromLatestEmail(1);
+
+        // Resend from the dashboard banner: a new link arrives...
+        mvc.perform(post("/auth/verify/resend")
+                        .with(user("resender").roles("STUDENT")).with(csrf()))
+                .andExpect(redirectedUrl("/dashboard?verification-sent"));
+        String secondToken = tokenFromLatestEmail(2);
+        assertThat(secondToken).isNotEqualTo(firstToken);
+
+        // ...the first link is invalidated, the fresh one works.
+        mvc.perform(get("/auth/verify").param("token", firstToken))
+                .andExpect(redirectedUrl("/auth/login?verify-invalid"));
+        mvc.perform(get("/auth/verify").param("token", secondToken))
+                .andExpect(redirectedUrl("/auth/login?verified"));
+    }
+
+    /**
+     * Polls Mailpit's REST API for the latest message and extracts the raw
+     * token from the verification link in its body.
+     */
+    private String tokenFromLatestEmail(int expectedCount) throws Exception {
+        String api = "http://" + MAILPIT.getHost() + ":" + MAILPIT.getMappedPort(8025);
+        String text = null;
+        for (int attempt = 0; attempt < 20 && text == null; attempt++) {
+            HttpResponse<String> list = http.send(
+                    HttpRequest.newBuilder(URI.create(api + "/api/v1/messages")).GET().build(),
+                    HttpResponse.BodyHandlers.ofString());
+            JsonNode messages = json.readTree(list.body()).path("messages");
+            if (messages.size() >= expectedCount) {
+                String id = messages.get(0).path("ID").asText();
+                HttpResponse<String> message = http.send(
+                        HttpRequest.newBuilder(URI.create(api + "/api/v1/message/" + id))
+                                .GET().build(),
+                        HttpResponse.BodyHandlers.ofString());
+                text = json.readTree(message.body()).path("Text").asText();
+            } else {
+                Thread.sleep(250);
+            }
+        }
+        assertThat(text).as("Mailpit received the verification email").isNotNull();
+        Matcher matcher = Pattern.compile("token=([A-Za-z0-9_-]+)").matcher(text);
+        assertThat(matcher.find()).as("verification link present in the email body").isTrue();
+        return matcher.group(1);
+    }
+}


### PR DESCRIPTION
This PR adds **email verification**.

User registration now **sends a verification link via email**.
It uses the `email_tokens` table and the boolean field `users.is_verified`.

The **verification token** present in the link adheres to the password reset policy, where:
- 32 random bytes are sent via email.
- Only the SHA-256 hash is stored.
- One active token per user.
- Single use.
- 24-hour TTL (meaning the token expires after 24-hours after it is generated) (The TTL is stored in `email_tokens.expires_at` as a timestamp with timezone). 
 
**`GET /auth/verify`** consumes the link.  
The dashboard shows a banner with a resend action until the address is verified.  
Verification is informational in v1: it gates nothing yet.  

> [!IMPORTANT]
> Verification link sending failures are logged and audited.
> These failures are never fatal to registration.

**`EmailVerificationFlowTest`** tests the email verification end-to-end through a real
*Mailpit* SMTP container:
- Register, 
- Capture the email,
- Follow the link,
- See the flag flip and the token burn,
- Resending invalidates the old token. 
- The new link works.