### PR TITLE
fix(config): Tolerate malformed lines in the generated .env

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,3 +1,14 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# spring-dotenv (.env loader)
+# The external secrets manager that generates .env prepends a localized
+# header, and some locales wrap the header's documentation URL onto a
+# bare, uncommented line, which dotenv-java rejects as a "Malformed
+# entry" and aborts startup. Tolerate non KEY=VALUE lines: real
+# variables still load, bogus header lines are skipped.
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+springdotenv:
+  ignore-if-malformed: true
+
 spring:
   application:
     name: learn-dev


### PR DESCRIPTION
## Problem

Starting the app with `make run` died before Spring even began:

>  DotenvException: Malformed entry <header documentation URL>


## Issue

The `.env` served by the external secrets manager carries a localized
header, and some locales wrap the header's documentation URL onto a
bare line **without the leading comment mark** (`#`). 

*Docker Compose* skips thatline, but *dotenv-java* rejects it, 
and *spring-dotenv* aborts the whole startup.

The issue seems related to localization.


## Workaround

The header generation is an upstream issue.
The workaround is to set `springdotenv.ignore-if-malformed` to `true` to make the loader skip
non `KEY=VALUE` lines instead of failing, so every real variable still loads whatever the header locale looks like.


## Long Term Fix

Filed a ticket on the external secrets manager for this upstream issue to be fixed.
